### PR TITLE
Minor refactor of binary reader and its tests.

### DIFF
--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -784,6 +784,9 @@ _bind_length_handlers(_CONTAINER_TIDS, _container_start_handler, _ALL_LENGTH_LNS
 _bind_length_handlers([_TypeID.ANNOTATION], _annotation_handler, _ANNOTATION_LENGTH_LNS)
 _bind_length_handlers([_TypeID.NULL], _nop_pad_handler, _ALL_LENGTH_LNS)
 
+# Make immutable.
+_HANDLER_DISPATCH_TABLE = tuple(_HANDLER_DISPATCH_TABLE)
+
 
 def raw_reader(queue=None):
     """Returns a raw binary reader co-routine.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,6 +24,14 @@ import pytest
 from contextlib import contextmanager
 
 
+def listify(iter_func):
+    """Takes an iterator function and returns a function that materializes it into a list."""
+    def delegate(*args, **kwargs):
+        return list(iter_func(*args, **kwargs))
+    delegate.__name__ = iter_func.__name__
+    return delegate
+
+
 @contextmanager
 def noop_manager():
     """A no-op context manager"""

--- a/tests/event_aliases.py
+++ b/tests/event_aliases.py
@@ -1,0 +1,60 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Python 2/3 compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+
+from amazon.ion.core import IonEvent, IonEventType, IonType, \
+                            ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, \
+                            ION_VERSION_MARKER_EVENT
+from amazon.ion.reader import NEXT_EVENT, SKIP_EVENT, read_data_event
+
+
+e_scalar = partial(IonEvent, IonEventType.SCALAR)
+e_null = partial(e_scalar, IonType.NULL)
+e_bool = partial(e_scalar, IonType.BOOL)
+e_int = partial(e_scalar, IonType.INT)
+e_float = partial(e_scalar, IonType.FLOAT)
+e_decimal = partial(e_scalar, IonType.DECIMAL)
+e_timestamp = partial(e_scalar, IonType.TIMESTAMP)
+e_symbol = partial(e_scalar, IonType.SYMBOL)
+e_string = partial(e_scalar, IonType.STRING)
+e_clob = partial(e_scalar, IonType.CLOB)
+e_blob = partial(e_scalar, IonType.BLOB)
+
+e_null_list = partial(e_scalar, IonType.LIST, None)
+e_null_sexp = partial(e_scalar, IonType.SEXP, None)
+e_null_struct = partial(e_scalar, IonType.STRUCT, None)
+
+e_start = partial(IonEvent, IonEventType.CONTAINER_START)
+e_start_list = partial(e_start, IonType.LIST)
+e_start_sexp = partial(e_start, IonType.SEXP)
+e_start_struct = partial(e_start, IonType.STRUCT)
+
+e_end = partial(IonEvent, IonEventType.CONTAINER_END)
+e_end_list = partial(e_end, IonType.LIST)
+e_end_sexp = partial(e_end, IonType.SEXP)
+e_end_struct = partial(e_end, IonType.STRUCT)
+
+NEXT = NEXT_EVENT
+SKIP = SKIP_EVENT
+e_read = read_data_event
+
+INC = ION_STREAM_INCOMPLETE_EVENT
+END = ION_STREAM_END_EVENT
+IVM = ION_VERSION_MARKER_EVENT

--- a/tests/reader_util.py
+++ b/tests/reader_util.py
@@ -1,0 +1,62 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Python 2/3 compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from pytest import raises
+
+from tests import is_exception
+
+from amazon.ion.core import IonEventType
+from amazon.ion.util import record
+
+
+def add_depths(events):
+    """Adds the appropriate depths to an iterable of :class:`IonEvent`."""
+    depth = 0
+    for event in events:
+        if is_exception(event):
+            # Special case for expectation of exception.
+            yield event
+        else:
+            if event.event_type == IonEventType.CONTAINER_END:
+                depth -= 1
+
+            if event.event_type.is_stream_signal:
+                yield event
+            else:
+                yield event.derive_depth(depth)
+
+            if event.event_type == IonEventType.CONTAINER_START:
+                depth += 1
+
+
+class ReaderParameter(record('desc', 'event_pairs')):
+    def __str__(self):
+        return self.desc
+
+
+def reader_scaffold(reader, event_pairs):
+    input_events = (e for e, _ in event_pairs)
+    output_events = add_depths(e for _, e in event_pairs)
+    for read_event, expected in zip(input_events, output_events):
+        if is_exception(expected):
+            with raises(expected):
+                reader.send(read_event)
+        else:
+            actual = reader.send(read_event)
+            assert expected == actual

--- a/tests/test_reader_base.py
+++ b/tests/test_reader_base.py
@@ -42,6 +42,7 @@ _P = TrampolineParameters
 
 _TRIVIAL_DATA_EVENT = read_data_event(b'DATA')
 
+
 @parametrize(
     _P(
         desc='START WITH NONE',

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -18,22 +18,17 @@ from __future__ import division
 from __future__ import print_function
 
 from decimal import Decimal
-from functools import partial
 from itertools import chain
 from random import Random
 from six import int2byte
 
-from pytest import raises
+from tests import parametrize, listify
+from tests.reader_util import reader_scaffold, ReaderParameter
+from tests.event_aliases import *
 
-from tests import parametrize, is_exception
-
-from amazon.ion.util import record
-from amazon.ion.core import ION_STREAM_END_EVENT, ION_STREAM_INCOMPLETE_EVENT, \
-                            ION_VERSION_MARKER_EVENT, \
-                            IonEvent, IonEventType, IonType, \
-                            timestamp, TimestampPrecision
+from amazon.ion.core import IonType, timestamp, TimestampPrecision
 from amazon.ion.exceptions import IonException
-from amazon.ion.reader import NEXT_EVENT, SKIP_EVENT, read_data_event, ReadEventType
+from amazon.ion.reader import read_data_event, ReadEventType
 from amazon.ion.reader_binary import raw_reader, _TypeID, _CONTAINER_TIDS, _TID_VALUE_TYPE_TABLE
 from amazon.ion.symbols import SYMBOL_ZERO_TOKEN, SymbolToken
 
@@ -43,201 +38,167 @@ _PREC_DAY = TimestampPrecision.DAY
 _PREC_MINUTE = TimestampPrecision.MINUTE
 _PREC_SECOND = TimestampPrecision.SECOND
 
-_e_scalar = partial(IonEvent, IonEventType.SCALAR)
-_e_null = partial(_e_scalar, IonType.NULL)
-_e_bool = partial(_e_scalar, IonType.BOOL)
-_e_int = partial(_e_scalar, IonType.INT)
-_e_float = partial(_e_scalar, IonType.FLOAT)
-_e_decimal = partial(_e_scalar, IonType.DECIMAL)
-_e_timestamp = partial(_e_scalar, IonType.TIMESTAMP)
-_e_symbol = partial(_e_scalar, IonType.SYMBOL)
-_e_string = partial(_e_scalar, IonType.STRING)
-_e_clob = partial(_e_scalar, IonType.CLOB)
-_e_blob = partial(_e_scalar, IonType.BLOB)
-
-_e_null_list = partial(_e_scalar, IonType.LIST, None)
-_e_null_sexp = partial(_e_scalar, IonType.SEXP, None)
-_e_null_struct = partial(_e_scalar, IonType.STRUCT, None)
-
-_e_start = partial(IonEvent, IonEventType.CONTAINER_START)
-_e_start_list = partial(_e_start, IonType.LIST)
-_e_start_sexp = partial(_e_start, IonType.SEXP)
-_e_start_struct = partial(_e_start, IonType.STRUCT)
-
-_e_end = partial(IonEvent, IonEventType.CONTAINER_END)
-_e_end_list = partial(_e_end, IonType.LIST)
-_e_end_sexp = partial(_e_end, IonType.SEXP)
-_e_end_struct = partial(_e_end, IonType.STRUCT)
-
 _ts = timestamp
 
-_NEXT = NEXT_EVENT
-_SKIP = SKIP_EVENT
-_D = read_data_event
+_P = ReaderParameter
 
-_INC = ION_STREAM_INCOMPLETE_EVENT
-_END = ION_STREAM_END_EVENT
-_IVM = ION_VERSION_MARKER_EVENT
-
-
-def _add_depths(events):
-    depth = 0
-    for event in events:
-        if event.event_type == IonEventType.CONTAINER_END:
-            depth -= 1
-
-        if event.event_type.is_stream_signal:
-            yield event
-        else:
-            yield event.derive_depth(depth)
-
-        if event.event_type == IonEventType.CONTAINER_START:
-            depth += 1
+_IVM_PAIRS =[
+    (NEXT, END),
+    (e_read(b'\xE0\x01\x00\xEA'), IVM)
+]
 
 
-class _P(record('desc', 'inputs', 'outputs')):
-    def __str__(self):
-        return self.desc
-
-
-_IVM_IN = [_NEXT, _D(b'\xE0\x01\x00\xEA')]
-_IVM_OUT = [_END, _IVM]
-
-
+@listify
 def _prepend_ivm(params):
-    out = []
     for p in params:
         new_p = _P(
             desc=p.desc,
-            inputs=_IVM_IN + p.inputs,
-            outputs=_IVM_OUT + p.outputs
+            event_pairs=_IVM_PAIRS + p.event_pairs
         )
-        out.append(new_p)
-    return out
+        yield new_p
 
 _BASIC_PARAMS = (
     _P(
         desc='EMPTY',
-        inputs=[_NEXT],
-        outputs=[_END],
+        event_pairs=[(NEXT, END)]
     ),
     _P(
         desc='IVM',
-        inputs=_IVM_IN,
-        outputs=_IVM_OUT,
+        event_pairs=_IVM_PAIRS,
     ),
     _P(
         desc='IVM PARTS',
-        inputs=[_NEXT, _D(b'\xE0\x01'), _D(b'\x00\xEA'), _NEXT],
-        outputs=[_END, _INC, _IVM, _END],
+        event_pairs=[
+            (NEXT, END),
+            (e_read(b'\xE0\x01'), INC),
+            (e_read(b'\x00\xEA'), IVM),
+            (NEXT, END),
+        ],
     ),
     _P(
         desc='IVM NOP IVM',
-        inputs=[_NEXT, _D(b'\xE0\x01\x00\xEA\x02\x00'), _NEXT, _D(b'\xFF\xE0\x01\x00\xEA'), _NEXT],
-        outputs=[_END, _IVM, _INC, _IVM, _END],
+        event_pairs=[
+            (NEXT, END),
+            (e_read(b'\xE0\x01\x00\xEA\x02\x00'), IVM),
+            (NEXT, INC),
+            (e_read(b'\xFF\xE0\x01\x00\xEA'), IVM),
+            (NEXT, END),
+        ],
     ),
     _P(
         desc='NO START IVM',
-        inputs=[_NEXT, _D(b'\x0F')],
-        outputs=[_END, IonException],
+        event_pairs=[
+            (NEXT, END),
+            (e_read(b'\x0F'), IonException),
+        ],
     ),
 )
 
 
 # This is an encoding of a single top-level value and the expected events with ``NEXT``.
 _TOP_LEVEL_VALUES = (
-    (b'\x0F', _e_null()),
+    (b'\x0F', e_null()),
 
-    (b'\x10', _e_bool(False)),
-    (b'\x11', _e_bool(True)),
-    (b'\x1F', _e_bool()),
+    (b'\x10', e_bool(False)),
+    (b'\x11', e_bool(True)),
+    (b'\x1F', e_bool()),
 
-    (b'\x2F', _e_int()),
-    (b'\x20', _e_int(0)),
-    (b'\x21\xFE', _e_int(0xFE)),
-    (b'\x22\x00\x01', _e_int(1)),
-    (b'\x24\x01\x2F\xEF\xCC', _e_int(0x12FEFCC)),
-    (b'\x29\x12\x34\x56\x78\x90\x12\x34\x56\x78', _e_int(0x123456789012345678)),
-    (b'\x2E\x81\x05', _e_int(5)), # Overpaded length.
+    (b'\x2F', e_int()),
+    (b'\x20', e_int(0)),
+    (b'\x21\xFE', e_int(0xFE)),
+    (b'\x22\x00\x01', e_int(1)),
+    (b'\x24\x01\x2F\xEF\xCC', e_int(0x12FEFCC)),
+    (b'\x29\x12\x34\x56\x78\x90\x12\x34\x56\x78', e_int(0x123456789012345678)),
+    (b'\x2E\x81\x05', e_int(5)), # Over padded length.
 
-    (b'\x31\x01', _e_int(-1)),
-    (b'\x32\xC1\xC2', _e_int(-0xC1C2)),
-    (b'\x36\xC1\xC2\x00\x00\x10\xFF', _e_int(-0xC1C2000010FF)),
-    (b'\x39\x12\x34\x56\x78\x90\x12\x34\x56\x78', _e_int(-0x123456789012345678)),
-    (b'\x3E\x82\x00\xA0', _e_int(-160)), # Overpadded length + overpadded integer.
+    (b'\x31\x01', e_int(-1)),
+    (b'\x32\xC1\xC2', e_int(-0xC1C2)),
+    (b'\x36\xC1\xC2\x00\x00\x10\xFF', e_int(-0xC1C2000010FF)),
+    (b'\x39\x12\x34\x56\x78\x90\x12\x34\x56\x78', e_int(-0x123456789012345678)),
+    (b'\x3E\x82\x00\xA0', e_int(-160)), # Over padded length + overpadded integer.
 
-    (b'\x4F', _e_float()),
-    (b'\x40', _e_float(0.0)),
-    (b'\x44\x3F\x80\x00\x00', _e_float(1.0)),
-    (b'\x44\x7F\x80\x00\x00', _e_float(float('+Inf'))),
-    (b'\x48\x42\x02\xA0\x5F\x20\x00\x00\x00', _e_float(1e10)),
-    (b'\x48\x7F\xF8\x00\x00\x00\x00\x00\x00', _e_float(float('NaN'))),
+    (b'\x4F', e_float()),
+    (b'\x40', e_float(0.0)),
+    (b'\x44\x3F\x80\x00\x00', e_float(1.0)),
+    (b'\x44\x7F\x80\x00\x00', e_float(float('+Inf'))),
+    (b'\x48\x42\x02\xA0\x5F\x20\x00\x00\x00', e_float(1e10)),
+    (b'\x48\x7F\xF8\x00\x00\x00\x00\x00\x00', e_float(float('NaN'))),
 
-    (b'\x5F', _e_decimal()),
-    (b'\x50', _e_decimal(Decimal())),
-    (b'\x52\x47\xE8', _e_decimal(Decimal('0e-1000'))),
-    (b'\x54\x07\xE8\x00\x00', _e_decimal(Decimal('0e1000'))),
-    (b'\x52\x81\x01', _e_decimal(Decimal('1e1'))),
-    (b'\x53\xD4\x04\xD2', _e_decimal(Decimal('1234e-20'))),
+    (b'\x5F', e_decimal()),
+    (b'\x50', e_decimal(Decimal())),
+    (b'\x52\x47\xE8', e_decimal(Decimal('0e-1000'))),
+    (b'\x54\x07\xE8\x00\x00', e_decimal(Decimal('0e1000'))),
+    (b'\x52\x81\x01', e_decimal(Decimal('1e1'))),
+    (b'\x53\xD4\x04\xD2', e_decimal(Decimal('1234e-20'))),
 
-    (b'\x6F', _e_timestamp()),
-    (b'\x63\xC0\x0F\xE0', _e_timestamp(_ts(2016, precision=_PREC_YEAR))), # -00:00
-    (b'\x63\x80\x0F\xE0', _e_timestamp(_ts(2016, off_hours=0, precision=_PREC_YEAR))),
+    (b'\x6F', e_timestamp()),
+    (b'\x63\xC0\x0F\xE0', e_timestamp(_ts(2016, precision=_PREC_YEAR))), # -00:00
+    (b'\x63\x80\x0F\xE0', e_timestamp(_ts(2016, off_hours=0, precision=_PREC_YEAR))),
     (
         b'\x64\x81\x0F\xE0\x82',
-        _e_timestamp(_ts(2016, 2, 1, 0, 1, off_minutes=1, precision=_PREC_MONTH))
+        e_timestamp(_ts(2016, 2, 1, 0, 1, off_minutes=1, precision=_PREC_MONTH))
     ),
     (
         b'\x65\xFC\x0F\xE0\x82\x82',
-        _e_timestamp(_ts(2016, 2, 1, 23, 0, off_hours=-1, precision=_PREC_DAY))
+        e_timestamp(_ts(2016, 2, 1, 23, 0, off_hours=-1, precision=_PREC_DAY))
     ),
     (
         b'\x68\x43\xA4\x0F\xE0\x82\x82\x87\x80',
-        _e_timestamp(_ts(2016, 2, 2, 0, 0, off_hours=-7, precision=_PREC_MINUTE))
+        e_timestamp(_ts(2016, 2, 2, 0, 0, off_hours=-7, precision=_PREC_MINUTE))
     ),
     (
         b'\x69\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E',
-        _e_timestamp(_ts(2016, 2, 2, 0, 0, 30, off_hours=-7, precision=_PREC_SECOND))
+        e_timestamp(_ts(2016, 2, 2, 0, 0, 30, off_hours=-7, precision=_PREC_SECOND))
     ),
     (
         b'\x6B\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E\xC3\x81',
-        _e_timestamp(_ts(2016, 2, 2, 0, 0, 30, 1000, off_hours=-7, precision=_PREC_SECOND))
+        e_timestamp(_ts(2016, 2, 2, 0, 0, 30, 1000, off_hours=-7, precision=_PREC_SECOND))
     ),
 
-    (b'\x7F', _e_symbol()),
-    (b'\x70', _e_symbol(SYMBOL_ZERO_TOKEN)),
-    (b'\x71\x02', _e_symbol(SymbolToken(None, 2))),
-    (b'\x7A' + b'\xFF' * 10, _e_symbol(SymbolToken(None, 0xFFFFFFFFFFFFFFFFFFFF))),
+    (b'\x7F', e_symbol()),
+    (b'\x70', e_symbol(SYMBOL_ZERO_TOKEN)),
+    (b'\x71\x02', e_symbol(SymbolToken(None, 2))),
+    (b'\x7A' + b'\xFF' * 10, e_symbol(SymbolToken(None, 0xFFFFFFFFFFFFFFFFFFFF))),
 
-    (b'\x8F', _e_string()),
-    (b'\x80', _e_string(u'')),
-    (b'\x84\xf0\x9f\x92\xa9', _e_string(u'\U0001F4A9')),
-    (b'\x88$ion_1_0', _e_string(u'$ion_1_0')),
+    (b'\x8F', e_string()),
+    (b'\x80', e_string(u'')),
+    (b'\x84\xf0\x9f\x92\xa9', e_string(u'\U0001F4A9')),
+    (b'\x88$ion_1_0', e_string(u'$ion_1_0')),
 
-    (b'\x9F', _e_clob()),
-    (b'\x90', _e_clob(b'')),
-    (b'\x94\xf0\x9f\x92\xa9', _e_clob(b'\xf0\x9f\x92\xa9')),
+    (b'\x9F', e_clob()),
+    (b'\x90', e_clob(b'')),
+    (b'\x94\xf0\x9f\x92\xa9', e_clob(b'\xf0\x9f\x92\xa9')),
 
-    (b'\xAF', _e_blob()),
-    (b'\xA0', _e_blob(b'')),
-    (b'\xA4\xf0\x9f\x92\xa9', _e_blob(b'\xf0\x9f\x92\xa9')),
+    (b'\xAF', e_blob()),
+    (b'\xA0', e_blob(b'')),
+    (b'\xA4\xf0\x9f\x92\xa9', e_blob(b'\xf0\x9f\x92\xa9')),
 
-    (b'\xBF', _e_null_list()),
-    (b'\xB0', _e_start_list(), _e_end_list()),
+    (b'\xBF', e_null_list()),
+    (b'\xB0', e_start_list(), e_end_list()),
     
-    (b'\xCF', _e_null_sexp()),
-    (b'\xC0', _e_start_sexp(), _e_end_sexp()),
+    (b'\xCF', e_null_sexp()),
+    (b'\xC0', e_start_sexp(), e_end_sexp()),
     
-    (b'\xDF', _e_null_struct()),
-    (b'\xD0', _e_start_struct(), _e_end_struct()),
+    (b'\xDF', e_null_struct()),
+    (b'\xD0', e_start_struct(), e_end_struct()),
 )
+
+
+def _top_level_event_pairs(data, events):
+    first = True
+    for event in events:
+        input_event = NEXT
+        if first:
+            input_event = e_read(data)
+            first = False
+        yield input_event, event
 
 
 def _top_level_iter():
     for seq in _TOP_LEVEL_VALUES:
         data = seq[0]
-        events = list(_add_depths(seq[1:]))
-        yield data, events
+        event_pairs = list(_top_level_event_pairs(data, seq[1:]))
+        yield data, event_pairs
 
 
 def _gen_type_len(tid, length):
@@ -262,12 +223,12 @@ def _top_level_value_params():
 
     The expectation is starting from an end of stream top-level context.
     """
-    for data, events in _top_level_iter():
+    for data, event_pairs in _top_level_iter():
+        _, first = event_pairs[0]
         yield _P(
             desc='TL %s - %s - %r' % \
-                 (events[0].event_type.name, events[0].ion_type.name, events[0].value),
-            inputs=[_NEXT, _D(data)] + [_NEXT] * len(events),
-            outputs=[_END] + events + [_END],
+                 (first.event_type.name, first.ion_type.name, first.value),
+            event_pairs=[(NEXT, END)] + event_pairs + [(NEXT, END)],
         )
 
 
@@ -277,36 +238,29 @@ def _annotate_params(params):
     The requirement is that the given parameters completely encapsulate a single value.
     """
     for param in params:
-        def annotated_inputs():
-            for event in param.inputs:
-                if event.type == ReadEventType.DATA:
-                    data_len = _TEST_ANNOTATION_LEN + len(event.data)
+        @listify
+        def annotated():
+            for input_event, output_event in param.event_pairs:
+                if input_event.type is ReadEventType.DATA:
+                    data_len = _TEST_ANNOTATION_LEN + len(input_event.data)
                     data = _gen_type_len(_TypeID.ANNOTATION, data_len) \
                            + _TEST_ANNOTATION_DATA \
-                           + event.data
-                    event = read_data_event(data)
-                yield event
-
-        def annotated_outputs():
-            first = True
-            for event in param.outputs:
-                if first and not event.event_type.is_stream_signal:
-                    event = event.derive_annotations(_TEST_ANNOTATION_SIDS)
-                    first = False
-                yield event
+                           + input_event.data
+                    input_event = read_data_event(data)
+                    output_event = output_event.derive_annotations(_TEST_ANNOTATION_SIDS)
+                yield input_event, output_event
 
         yield _P(
             desc='ANN %s' % param.desc,
-            inputs=list(annotated_inputs()),
-            outputs=list(annotated_outputs()),
+            event_pairs=annotated(),
         )
 
 
-def _data_event_len(events):
+def _data_event_len(event_pairs):
     length = 0
-    for event in events:
-        if event.type is ReadEventType.DATA:
-            length += len(event.data)
+    for read_event, _ in event_pairs:
+        if read_event.type is ReadEventType.DATA:
+            length += len(read_event.data)
     return length
 
 
@@ -319,7 +273,7 @@ def _containerize_params(params, with_skip=True):
     rnd.seed(0xC0FFEE)
     params = list(params)
     for param in params:
-        data_len = _data_event_len(param.inputs)
+        data_len = _data_event_len(param.event_pairs)
         for tid in _CONTAINER_TIDS:
             ion_type = _TID_VALUE_TYPE_TABLE[tid]
 
@@ -332,57 +286,61 @@ def _containerize_params(params, with_skip=True):
                 field_tok = SymbolToken(None, field_sid)
                 field_desc = ' (f:0x%02X)' % field_sid
 
-            def field_name_outputs(events):
+            @listify
+            def add_field_names(event_pairs):
                 first = True
-                for event in events:
-                    if first and not event.event_type.is_stream_signal:
-                        event = event.derive_field_name(field_tok)
+                for read_event, ion_event in event_pairs:
+                    if first and not ion_event.event_type.is_stream_signal:
+                        ion_event = ion_event.derive_field_name(field_tok)
                         first = False
-                    yield event
+                    yield read_event, ion_event
 
             type_header = _gen_type_len(tid, data_len + len(field_data)) + field_data
-            inputs = [_NEXT, _D(type_header)] + param.inputs + [_NEXT]
 
-            out_start = [_END, _e_start(ion_type), _INC]
-            out_mid = list(field_name_outputs(param.outputs[1:-1]))
-            out_end = [_e_end(ion_type), _END]
-            outputs = list(_add_depths(chain(out_start, out_mid, out_end)))
+            start = [
+                (NEXT, END),
+                (e_read(type_header), e_start(ion_type)),
+                (NEXT, INC)
+            ]
+            mid = add_field_names(param.event_pairs[1:-1])
+            end = [(NEXT, e_end(ion_type)), (NEXT, END)]
 
             desc = 'SINGLETON %s%s - %s' % (ion_type.name, field_desc, param.desc)
             yield _P(
                 desc=desc,
-                inputs=inputs,
-                outputs=outputs,
+                event_pairs=start + mid + end,
             )
 
             # Version with SKIP
             if with_skip:
-                def only_data(events):
-                    for event in events:
-                        if event.type is ReadEventType.DATA:
-                            yield event
+                @listify
+                def only_data_inc(event_pairs):
+                    for read_event, ion_event in event_pairs:
+                        if read_event.type is ReadEventType.DATA:
+                            yield read_event, INC
 
-                data_events = list(only_data(param.inputs))
-                inputs = [_NEXT, _D(type_header), _SKIP] + data_events + [_NEXT]
-                out_start = out_start[:-1] + [_INC] * len(data_events)
-                outputs = list(_add_depths(chain(out_start, out_end)))
+                start = start[:-1] + [(SKIP, INC)]
+                end = only_data_inc(param.event_pairs)
+                end = end[:-1] + [(end[-1][0], e_end(ion_type)), (NEXT, END)]
+                
                 yield _P(
                     desc='SKIP %s' % desc,
-                    inputs=inputs,
-                    outputs=outputs
+                    event_pairs=start + end,
                 )
 
 
 def _all_top_level_as_one_stream_params():
-    inputs = [_NEXT]
-    outputs = [_END]
-    for data, events in _top_level_iter():
-        inputs.extend([_D(data)] + [_NEXT] * len(events))
-        outputs.extend(events + [_END])
+    @listify
+    def generate_event_pairs():
+        yield (NEXT, END)
+        for data, event_pairs in _top_level_iter():
+            for event_pair in event_pairs:
+                yield event_pair
+            yield (NEXT, END)
+
     yield _P(
         desc='TOP LEVEL ALL',
-        inputs=inputs,
-        outputs=outputs,
+        event_pairs=generate_event_pairs()
     )
 
 # TODO Add NOP pad fuzz.
@@ -394,15 +352,12 @@ def _all_top_level_as_one_stream_params():
     _prepend_ivm(_top_level_value_params()),
     _prepend_ivm(_annotate_params(_top_level_value_params())),
     _prepend_ivm(_containerize_params(_top_level_value_params())),
-    _prepend_ivm(_containerize_params(_containerize_params(_top_level_value_params(), with_skip=False))),
+    _prepend_ivm(
+        _containerize_params(
+            _containerize_params(_top_level_value_params(), with_skip=False)
+        )
+    ),
     _prepend_ivm(_all_top_level_as_one_stream_params()),
 ))
 def test_raw_reader(p):
-    reader = raw_reader()
-    for read_event, expected in zip(p.inputs, p.outputs):
-        if is_exception(expected):
-            with raises(expected):
-                reader.send(read_event)
-        else:
-            actual = reader.send(read_event)
-            assert expected == actual
+    reader_scaffold(raw_reader(), p.event_pairs)


### PR DESCRIPTION
Makes the reader dispatch table an immutable tuple.
Refactors binary reader tests common code out into utility.
Changes reader tests to use event pairs to make it easier to write tests.
Refactors binary reader tests to use this.

Supports #26.