### PR TITLE
simpleion API

### DIFF
--- a/amazon/ion/__init__.py
+++ b/amazon/ion/__init__.py
@@ -23,8 +23,16 @@ __version__ = '0.1.0'
 __all__ = [
     'core',
     'exceptions',
+    'reader',
+    'reader_binary',
+    'reader_managed',
+    'simple_types',
     'symbols',
     'util',
     'writer',
+    'writer_binary',
+    'writer_binary_raw',
+    'writer_binary_raw_fields',
+    'writer_buffer',
     'writer_text',
 ]

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -135,8 +135,8 @@ class IonEvent(record(
             # Timestamp precision has additional requirements.
             if isinstance(self.value, Timestamp) or isinstance(other.value, Timestamp):
                 # Special case for timestamps to capture equivalence over precision.
-                self_precision = getattr(self.value, _TS_PRECISION_FIELD)
-                other_precision = getattr(other.value, _TS_PRECISION_FIELD)
+                self_precision = getattr(self.value, TIMESTAMP_PRECISION_FIELD, None)
+                other_precision = getattr(other.value, TIMESTAMP_PRECISION_FIELD, None)
                 if self_precision != other_precision:
                     return False
             if isinstance(self.value, datetime):
@@ -354,7 +354,7 @@ class TimestampPrecision(Enum):
         return self >= TimestampPrecision.SECOND
 
 
-_TS_PRECISION_FIELD = 'precision'
+TIMESTAMP_PRECISION_FIELD = 'precision'
 
 
 class Timestamp(datetime):
@@ -363,17 +363,17 @@ class Timestamp(datetime):
     Notes:
         The ``precision`` field is passed as a keyword argument of the same name.
     """
-    __slots__ = [_TS_PRECISION_FIELD]
+    __slots__ = [TIMESTAMP_PRECISION_FIELD]
 
     def __new__(cls, *args, **kwargs):
         precision = None
-        if _TS_PRECISION_FIELD in kwargs:
-            precision = kwargs.get(_TS_PRECISION_FIELD)
+        if TIMESTAMP_PRECISION_FIELD in kwargs:
+            precision = kwargs.get(TIMESTAMP_PRECISION_FIELD)
             # Make sure we mask this before we construct the datetime.
-            del kwargs[_TS_PRECISION_FIELD]
+            del kwargs[TIMESTAMP_PRECISION_FIELD]
 
         instance = super(Timestamp, cls).__new__(cls, *args, **kwargs)
-        setattr(instance, _TS_PRECISION_FIELD, precision)
+        setattr(instance, TIMESTAMP_PRECISION_FIELD, precision)
 
         return instance
 

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -193,6 +193,7 @@ def _parse_decimal(buf):
         # Handle the zero cases--especially negative zero
         value = Decimal((sign_bit, (0,), exponent))
     else:
+        coefficient *= sign_bit and -1 or 1
         value = Decimal(coefficient).scaleb(exponent)
 
     return value

--- a/amazon/ion/reader_managed.py
+++ b/amazon/ion/reader_managed.py
@@ -110,7 +110,7 @@ def _managed_thunk_event(ctx, ion_event):
 
     def value_thunk():
         value = ion_event.value
-        if ion_type is IonType.SYMBOL:
+        if ion_type is IonType.SYMBOL and value is not None:
             value = ctx.resolve(value)
         return value
 
@@ -309,6 +309,7 @@ def managed_reader(reader, catalog=None):
 
                     elif ion_type is IonType.SYMBOL \
                             and len(ion_event.annotations) == 0 \
+                            and ion_event.value is not None \
                             and ctx.resolve(ion_event.value).text == TEXT_ION_1_0:
                         assert symbol_trans.delegate is None
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -115,22 +115,11 @@ class _IonNature(object):
                                       annotations=self.ion_annotations, depth=depth)
         return self.ion_event
 
-    def annotation_str(self):
-        out = ''
-        for annotation in self.ion_annotations:
-            out += annotation + '::'
-        return out
-
 
 def _ion_type_for(name, base_cls):
     class IonPyValueType(base_cls, _IonNature):
         def __init__(self, *args, **kwargs):
             super(IonPyValueType, self).__init__(*args, **kwargs)
-
-        def __str__(self):
-            return self.annotation_str() + super(IonPyValueType, self).__repr__()
-
-        __repr__ = __str__
 
     IonPyValueType.__name__ = name
     return IonPyValueType
@@ -142,12 +131,7 @@ else:
     IonPyInt = _ion_type_for('IonPyInt', int)
 
 
-class IonPyBool(IonPyInt):
-    def __str__(self):
-        return self.annotation_str() + str(bool(self)).lower()  # TODO ion representation or python representation?
-
-    __repr__ = __str__
-
+IonPyBool = IonPyInt
 IonPyFloat = _ion_type_for('IonPyFloat', float)
 IonPyDecimal = _ion_type_for('IonPyDecimal', Decimal)
 IonPyText = _ion_type_for('IonPyText', six.text_type)
@@ -210,11 +194,6 @@ class IonPyNull(_IonNature):
 
     def __bool__(self):
         return False
-
-    def __str__(self):
-        return self.annotation_str() + str(_NULL_TYPE_NAMES[self.ion_type], 'utf-8')
-
-    __repr__ = __str__
 
     @staticmethod
     def _to_constructor_args(value):

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -1,0 +1,155 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+"""The type mappings for the ``simplejson``-like API.
+
+In particular, this module provides the extension to native Python data types with
+particulars of the Ion data model.
+"""
+
+# Python 2/3 compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
+from decimal import Decimal
+
+from .core import Timestamp
+from .core import TIMESTAMP_PRECISION_FIELD
+
+
+class _IonNature(object):
+    """Mix-in for Ion related properties.
+
+    Attributes:
+        ion_event (Optional[IonEvent]): The event, if any associated with the value.
+        ion_type (IonType): The Ion type for the value.
+        ion_annotations (Sequence[unicode]): The annotations associated with the value.
+
+    Notes:
+        There is no ``field_name`` attribute as that is generally modeled as a property of the
+        container.
+
+        The ``ion_event`` field is only provided if the value was derived from a low-level event.
+        User constructed values will generally not set this field.
+    """
+    def __init__(self, *args, **kwargs):
+        self.ion_event = None
+        self.ion_type = None
+        self.ion_annotations = ()
+
+    @staticmethod
+    def _to_constructor_args(value):
+        return (value, ), {}
+
+    @classmethod
+    def from_event(cls, ion_event):
+        """Constructs the given native extension from the properties of an event.
+
+        Args:
+            ion_event (IonEvent): The event to construct the native value from.
+        """
+        args, kwargs = cls._to_constructor_args(ion_event.value)
+        value = cls(*args, **kwargs)
+        value.ion_event = ion_event
+        value.ion_type = ion_event.ion_type
+        value.ion_annotations = tuple(x.text for x in ion_event.annotations)
+        return value
+
+    @classmethod
+    def from_value(cls, ion_type, value, annotations=()):
+        """Constructs a value as a copy with an associated Ion type and annotations.
+
+        Args:
+            ion_type (IonType): The associated Ion type.
+            value (Any): The value to construct from, generally of type ``cls``.
+            annotations (Sequence[unicode]):  The sequence Unicode strings decorating this value.
+        """
+        args, kwargs = cls._to_constructor_args(value)
+        value = cls(*args, **kwargs)
+        value.ion_event = None
+        value.ion_type = ion_type
+        value.ion_annotations = annotations
+        return value
+
+
+def _ion_type_for(name, base_cls):
+    class IonPyValueType(base_cls, _IonNature):
+        def __init__(self, *args, **kwargs):
+            super(IonPyValueType, self).__init__(*args, **kwargs)
+
+    IonPyValueType.__name__ = name
+    return IonPyValueType
+
+
+if six.PY2:
+    IonPyInt = _ion_type_for('IonPyInt', long)
+else:
+    IonPyInt = _ion_type_for('IonPyInt', int)
+
+IonPyBool = IonPyInt
+IonPyFloat = _ion_type_for('IonPyFloat', float)
+IonPyDecimal = _ion_type_for('IonPyDecimal', Decimal)
+IonPyText = _ion_type_for('IonPyText', six.text_type)
+IonPyBytes = _ion_type_for('IonPyBytes', six.binary_type)
+
+
+class IonPyTimestamp(Timestamp, _IonNature):
+    def __init__(self, *args, **kwargs):
+        super(IonPyTimestamp, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _to_constructor_args(ts):
+        args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
+        kwargs = {}
+        precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
+        if precision is not None:
+            kwargs[TIMESTAMP_PRECISION_FIELD] = precision
+        return args, kwargs
+
+
+class IonPyNull(_IonNature):
+    """Representation of ``null``.
+
+    Notes:
+        ``None`` is a singleton and cannot be sub-classed, so we have our
+         own value type for it.  The function ``is_null`` is the best way
+         to test for ``null``-ness or ``None``-ness.
+    """
+    def __init__(self, *args, **kwargs):
+        super(IonPyNull, self).__init__(*args, **kwargs)
+
+    def __eq__(self, other):
+        return isinstance(other, IonPyNull)
+
+    def __nonzero__(self):
+        return False
+
+    def __bool__(self):
+        return False
+
+    @staticmethod
+    def _to_constructor_args(value):
+        return (), {}
+
+
+def is_null(value):
+    """A mechanism to determine if a value is ``None`` or an Ion ``null``."""
+    return value is None or isinstance(value, IonPyNull)
+
+
+IonPyList = _ion_type_for('IonPyList', list)
+IonPyDict = _ion_type_for('IonPyDict', dict)

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -74,7 +74,7 @@ class _IonNature(object):
         value = cls(*args, **kwargs)
         value.ion_event = ion_event
         value.ion_type = ion_event.ion_type
-        value.ion_annotations = tuple(x.text for x in ion_event.annotations)
+        value.ion_annotations = ion_event.annotations
         return value
 
     @classmethod

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -149,7 +149,7 @@ _FROM_TYPE = dict(chain(
         dict: IonType.STRUCT
     }),
     six.iteritems(
-        dict(zip(six.integer_types, [IonType.INT * len(six.integer_types)]))
+        dict(zip(six.integer_types, [IonType.INT] * len(six.integer_types)))
     ),
 ))
 
@@ -159,10 +159,7 @@ def _ion_type(obj):
         ion_type = _FROM_TYPE[type(obj)]
     except KeyError:
         raise TypeError('Unknown scalar type %r' % (type(obj),))
-    # The _FROM_TYPE dict seems to lose the 'IonType' nature sometimes, simply returning an int, which is problematic
-    # later when using IonType properties like 'is_container'. This ensures that an actual IonType is returned.
-    # TODO investigate why this is the case.
-    return IonType._enum_members[ion_type]
+    return ion_type
 
 
 def _dump(obj, writer, field=None):

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -1,0 +1,296 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+#
+# MIT License
+# ===========
+#
+# Copyright (c) 2006 Bob Ippolito
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Academic Free License v. 2.1
+# ============================
+#
+# Copyright (c) 2006 Bob Ippolito.  All rights reserved.
+#
+# This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose
+# owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original
+# Work:
+#
+# Licensed under the Academic Free License version 2.1
+#
+# 1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual,
+# sublicenseable license to do the following:
+#
+# a) to reproduce the Original Work in copies;
+#
+# b) to prepare derivative works ("Derivative Works") based upon the Original Work;
+#
+# c) to distribute copies of the Original Work and Derivative Works to the public;
+#
+# d) to perform the Original Work publicly; and
+#
+# e) to display the Original Work publicly.
+#
+# 2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual,
+# sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work
+# as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.
+#
+# 3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making
+# modifications to it and all available documentation describing how to modify the Original Work. Licensor hereby agrees
+# to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work
+# that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy
+# of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by
+# You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that
+# information repository in a notice immediately following the copyright notice that applies to the Original Work.
+#
+# 4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original
+# Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this
+# Original Work without express prior written permission of the Licensor. Nothing in this License shall be deemed to
+# grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor
+# except as expressly stated herein. No patent license is granted to make, use, sell or offer to sell embodiments of any
+# patent claims other than the licensed claims defined in Section 2. No right is granted to the trademarks of Licensor
+# even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit
+# Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a
+# right to license.
+#
+# 5) This section intentionally omitted.
+#
+# 6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright,
+# patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any
+# descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative
+# Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have
+# modified the Original Work.
+#
+# 7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work
+# and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms
+# of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly
+# stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS
+# and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT,
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH
+# YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to Original Work is granted
+# hereunder except under this disclaimer.
+#
+# 8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence),
+# contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or
+# consequential damages of any character arising as a result of this License or the use of the Original Work including,
+# without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other
+# commercial damages or losses. This limitation of liability shall not apply to liability for death or personal injury
+# resulting from Licensor's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not
+# allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not
+# apply to You.
+#
+# 9) Acceptance and Termination. If You distribute copies of the Original Work or a Derivative Work, You must make a
+# reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License.
+# Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create
+# Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any
+# attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is
+# expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty.
+# Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this
+# License and all of its terms and conditions.
+#
+# 10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of
+# the rights granted to You by this License as of the date You commence an action, including a cross-claim or
+# counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination
+# provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other
+# software or hardware.
+#
+# 11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the
+# courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under
+# the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations
+# Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work
+# outside the scope of this License or after its termination shall be subject to the requirements and penalties of the
+# U.S. Copyright Act, 17 U.S.C. § 101 et seq., the equivalent laws of other countries, and international treaty. This
+# section shall survive the termination of this License.
+#
+# 12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the
+# prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable
+# attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section
+# shall survive the termination of this License.
+#
+# 13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof. If any
+# provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary
+# to make it enforceable.
+#
+# 14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an
+# individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal
+# entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes
+# of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such
+# entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares,
+# or (iii) beneficial ownership of such entity.
+#
+# 15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or
+# by law, and Licensor promises not to interfere with or be responsible for such uses by You.
+#
+# This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby granted to copy
+# and distribute this license without modification. This license may not be modified without the express written
+# permission of its copyright owner.
+
+"""Provides a ``simplejson``-like API for dumping and loading Ion data.
+
+Because certain parts of this module are derived from simplejson, this file includes the license notices (MIT and
+AFL v2.1) from simplejson.
+"""
+
+# Python 2/3 compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
+from amazon.ion.core import IonEvent, IonEventType, IonType, ION_STREAM_END_EVENT
+from amazon.ion.exceptions import IonException
+from amazon.ion.reader import blocking_reader, NEXT_EVENT
+from amazon.ion.reader_binary import raw_reader
+from amazon.ion.reader_managed import managed_reader
+from amazon.ion.simple_types import IonPyList, IonPyDict, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, IonPyDecimal, \
+    IonPyTimestamp, IonPyText, IonPyBytes, _IonNature
+from amazon.ion.writer import blocking_writer
+from amazon.ion.writer_binary import binary_writer
+
+
+_ION_CONTAINER_END_EVENT = IonEvent(IonEventType.CONTAINER_END)
+
+
+def dump(obj, fp, imports=None, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
+         separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
+         tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
+         ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+    writer = blocking_writer(binary_writer(imports), fp)
+    _dump(obj, writer)
+    writer.send(ION_STREAM_END_EVENT)
+
+
+def _dump(obj, writer, field=None):
+    event = None
+    if obj is None:
+        event = IonEvent(IonEventType.SCALAR, IonType.NULL, field_name=field)
+    elif obj is True:
+        event = IonEvent(IonEventType.SCALAR, IonType.BOOL, True, field_name=field)
+    elif obj is False:
+        event = IonEvent(IonEventType.SCALAR, IonType.BOOL, False, field_name=field)
+    elif isinstance(obj, _IonNature):
+        if isinstance(obj, dict) or isinstance(obj, list):
+            event = obj.to_event(IonEventType.CONTAINER_START, field_name=field)
+        else:
+            event = obj.to_event(IonEventType.SCALAR, field_name=field)
+    elif isinstance(obj, six.integer_types):
+        event = IonEvent(IonEventType.SCALAR, IonType.INT, obj, field_name=field)
+    elif isinstance(obj, float):
+        event = IonEvent(IonEventType.SCALAR, IonType.FLOAT, obj, field_name=field)
+    elif isinstance(obj, six.text_type):
+        event = IonEvent(IonEventType.SCALAR, IonType.STRING, obj, field_name=field)
+
+    if isinstance(obj, dict):
+        if event is None:
+            event = IonEvent(IonEventType.CONTAINER_START, IonType.STRUCT, field_name=field)
+        writer.send(event)
+        for field, val in six.iteritems(obj):
+            _dump(val, writer, field)
+        writer.send(IonEvent(IonEventType.CONTAINER_END))
+    elif isinstance(obj, list):
+        if event is None:
+            event = IonEvent(IonEventType.CONTAINER_START, IonType.LIST, field_name=field)
+        writer.send(event)
+        for elem in obj:
+            _dump(elem, writer)
+        writer.send(IonEvent(IonEventType.CONTAINER_END))
+    else:
+        writer.send(event)
+
+
+def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
+          separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
+          tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
+          ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+    raise IonException("Not yet implemented")
+
+
+def load(fp, catalog=None, single_value=False, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
+         parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, **kw):
+    reader = blocking_reader(managed_reader(raw_reader(), catalog), fp)
+    out = []  # top-level
+    _load(out, reader)
+    if single_value:
+        if len(out) != 1:
+            raise IonException('Stream contained more than a single value')
+        return out[0]
+    return out
+
+
+def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
+
+    def add(obj):
+        if in_struct:
+            # TODO what about duplicate field names?
+            out[event.field_name.text] = obj
+        else:
+            out.append(obj)
+
+    event = reader.send(NEXT_EVENT)
+    while event.event_type is not end_type:
+        if event.event_type is IonEventType.CONTAINER_START:
+            # TODO any difference between list and sexp?
+            if event.ion_type is IonType.LIST or event.ion_type is IonType.SEXP:
+                lst = IonPyList.from_event(event)
+                _load(lst, reader, IonEventType.CONTAINER_END)
+                add(lst)
+            elif event.ion_type is IonType.STRUCT:
+                dct = IonPyDict.from_event(event)
+                _load(dct, reader, IonEventType.CONTAINER_END, True)
+                add(dct)
+            else:
+                raise ValueError("Illegal IonType for %r: %r " % (event.event_type, event.ion_type))
+        elif event.event_type is IonEventType.SCALAR:
+            if event.ion_type is IonType.NULL:
+                add(IonPyNull.from_event(event))
+            elif event.ion_type is IonType.BOOL:
+                add(IonPyBool.from_event(event))
+            elif event.ion_type is IonType.INT:
+                add(IonPyInt.from_event(event))
+            elif event.ion_type is IonType.FLOAT:
+                add(IonPyFloat.from_event(event))
+            elif event.ion_type is IonType.DECIMAL:
+                add(IonPyDecimal.from_event(event))
+            elif event.ion_type is IonType.TIMESTAMP:
+                add(IonPyTimestamp.from_event(event))
+            elif event.ion_type is IonType.SYMBOL or event.ion_type is IonType.STRING:
+                add(IonPyText.from_event(event))
+            elif event.ion_type is IonType.BLOB or event.ion_type is IonType.CLOB:
+                add(IonPyBytes.from_event(event))
+            else:
+                raise ValueError("Illegal IonType for %r: %r " % (event.event_type, event.ion_type))
+        event = reader.send(NEXT_EVENT)
+
+
+def loads(fp, encoding='utf-8', cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None,
+          object_pairs_hook=None, use_decimal=None, **kw):
+    raise IonException("Not yet implemented")

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -21,16 +21,17 @@ from __future__ import print_function
 
 from datetime import datetime
 from decimal import Decimal
+from itertools import chain
 
 import six
 
-from .core import IonEvent, IonEventType, IonType, ION_STREAM_END_EVENT
+from .core import IonEvent, IonEventType, IonType, ION_STREAM_END_EVENT, Timestamp
 from .exceptions import IonException
 from .reader import blocking_reader, NEXT_EVENT
 from .reader_binary import raw_reader
 from .reader_managed import managed_reader
 from .simple_types import IonPyList, IonPyDict, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, IonPyDecimal, \
-    IonPyTimestamp, IonPyText, IonPyBytes, _IonNature, IonPySymbol, is_null
+    IonPyTimestamp, IonPyText, IonPyBytes, IonPySymbol, is_null
 from .symbols import SymbolToken
 from .writer import blocking_writer
 from .writer_binary import binary_writer
@@ -43,6 +44,85 @@ def dump(obj, fp, imports=None, sequence_as_stream=False, skipkeys=False, ensure
          separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
          tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
          ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+    """Serialize ``obj`` as an Ion-formatted stream to ``fp`` (a file-like object), using the following conversion
+    table::
+        +-------------------+-------------------+
+        |  Python           |       Ion         |
+        |-------------------+-------------------|
+        | None              |    null.null      |
+        |-------------------+-------------------|
+        | IonPyNull(<type>) |    null.<type>    |
+        |-------------------+-------------------|
+        | True, False,      |                   |
+        | IonPyInt(BOOL),   |     bool          |
+        | IonPyBool,        |                   |
+        |-------------------+-------------------|
+        | int (Python 2, 3) |                   |
+        | long (Python 2),  |      int          |
+        | IonPyInt(INT)     |                   |
+        |-------------------+-------------------|
+        | float, IonPyFloat |     float         |
+        |-------------------+-------------------|
+        | Decimal,          |                   |
+        | IonPyDecimal      |     decimal       |
+        |-------------------+-------------------|
+        | datetime,         |                   |
+        | Timestamp,        |    timestamp      |
+        | IonPyTimestamp    |                   |
+        |-------------------+-------------------|
+        | SymbolToken,      |                   |
+        | IonPySymbol,      |     symbol        |
+        | IonPyText(SYMBOL) |                   |
+        |-------------------+-------------------|
+        | str (Python 3),   |                   |
+        | unicode (Python2),|     string        |
+        | IonPyText(STRING) |                   |
+        |-------------------+-------------------|
+        | IonPyBytes(CLOB)  |     clob          |
+        |-------------------+-------------------|
+        | str (Python 2),   |                   |
+        | bytes (Python 3)  |     blob          |
+        | IonPyBytes(BLOB)  |                   |
+        |-------------------+-------------------|
+        | list, tuple,      |                   |
+        | IonPyList(LIST)   |     list          |
+        |-------------------+-------------------|
+        | IonPyList(SEXP)   |     sexp          |
+        |-------------------+-------------------|
+        | dict, namedtuple, |                   |
+        | IonPyDict         |     struct        |
+        +-------------------+-------------------+
+
+    Args:
+        obj (Any): A python object to serialize according to the above table. Any Python types encountered in the object
+             not present in the above table will raise TypeError.
+        fp (BaseIO): A file-like object.
+        imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
+        sequence_as_stream (Optional[True|False]): When True, if ``obj`` is a sequence, it will be treated as a stream
+            of top-level Ion values (i.e. the resulting Ion data will begin with ``obj``'s first element).
+            Default: False.
+        skipkeys: NOT IMPLEMENTED
+        ensure_ascii: NOT IMPLEMENTED
+        check_circular: NOT IMPLEMENTED
+        allow_nan: NOT IMPLEMENTED
+        cls: NOT IMPLEMENTED
+        indent: NOT IMPLEMENTED
+        separators: NOT IMPLEMENTED
+        encoding: NOT IMPLEMENTED
+        default: NOT IMPLEMENTED
+        use_decimal: NOT IMPLEMENTED
+        namedtuple_as_object: NOT IMPLEMENTED
+        tuple_as_array: NOT IMPLEMENTED
+        bigint_as_string: NOT IMPLEMENTED
+        sort_keys: NOT IMPLEMENTED
+        item_sort_key: NOT IMPLEMENTED
+        for_json: NOT IMPLEMENTED
+        ignore_nan: NOT IMPLEMENTED
+        int_as_string_bitcount: NOT IMPLEMENTED
+        iterable_as_array: NOT IMPLEMENTED
+        **kw: NOT IMPLEMENTED
+
+    """
     writer = blocking_writer(binary_writer(imports), fp)
     if sequence_as_stream and isinstance(obj, (list, tuple)):
         # Treat this top-level sequence as a stream; serialize its elements as top-level values, but don't serialize the
@@ -53,33 +133,36 @@ def dump(obj, fp, imports=None, sequence_as_stream=False, skipkeys=False, ensure
         _dump(obj, writer)
     writer.send(ION_STREAM_END_EVENT)
 
+_FROM_TYPE = dict(chain(
+    six.iteritems({
+        type(None): IonType.NULL,
+        type(True): IonType.BOOL,
+        type(False): IonType.BOOL,
+        float: IonType.FLOAT,
+        six.text_type: IonType.STRING,
+        Decimal: IonType.DECIMAL,
+        datetime: IonType.TIMESTAMP,
+        Timestamp: IonType.TIMESTAMP,
+        six.binary_type: IonType.BLOB,
+        SymbolToken: IonType.SYMBOL,
+        list: IonType.LIST,
+        dict: IonType.STRUCT
+    }),
+    six.iteritems(
+        dict(zip(six.integer_types, [IonType.INT * len(six.integer_types)]))
+    ),
+))
+
 
 def _ion_type(obj):
-    if obj is None:
-        ion_type = IonType.NULL
-    elif obj is True or obj is False:
-        ion_type = IonType.BOOL
-    elif isinstance(obj, six.integer_types):
-        ion_type = IonType.INT
-    elif isinstance(obj, float):
-        ion_type = IonType.FLOAT
-    elif isinstance(obj, six.text_type):
-        ion_type = IonType.STRING
-    elif isinstance(obj, Decimal):
-        ion_type = IonType.DECIMAL
-    elif isinstance(obj, datetime):  # TODO accept 'Timestamp' too?
-        ion_type = IonType.TIMESTAMP
-    elif isinstance(obj, six.binary_type):
-        ion_type = IonType.BLOB
-    elif isinstance(obj, SymbolToken):
-        ion_type = IonType.SYMBOL
-    elif isinstance(obj, list):
-        ion_type = IonType.LIST
-    elif isinstance(obj, dict):
-        ion_type = IonType.STRUCT
-    else:
-        raise ValueError('Unknown scalar type %r' % (type(obj),))
-    return ion_type
+    try:
+        ion_type = _FROM_TYPE[type(obj)]
+    except KeyError:
+        raise TypeError('Unknown scalar type %r' % (type(obj),))
+    # The _FROM_TYPE dict seems to lose the 'IonType' nature sometimes, simply returning an int, which is problematic
+    # later when using IonType properties like 'is_container'. This ensures that an actual IonType is returned.
+    # TODO investigate why this is the case.
+    return IonType._enum_members[ion_type]
 
 
 def _dump(obj, writer, field=None):
@@ -116,11 +199,67 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan
           separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
           tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
           ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+    """Not yet implemented"""
     raise IonException("Not yet implemented")
 
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, **kw):
+    """Deserialize ``fp`` (a file-like object), which contains an Ion stream, to a Python object using the following
+    conversion table::
+        +-------------------+-------------------+
+        |  Ion              |     Python        |
+        |-------------------+-------------------|
+        | null.<type>       | IonPyNull(<type>) |
+        |-------------------+-------------------|
+        | bool              |    IonPyBool      |
+        |-------------------+-------------------|
+        | int               |    IonPyInt       |
+        |-------------------+-------------------|
+        | float             |    IonPyFloat     |
+        |-------------------+-------------------|
+        | decimal           |   IonPyDecimal    |
+        |-------------------+-------------------|
+        | timestamp         |  IonPyTimestamp   |
+        |-------------------+-------------------|
+        | symbol            |   IonPySymbol     |
+        |-------------------+-------------------|
+        | string            | IonPyText(STRING) |
+        |-------------------+-------------------|
+        | clob              |  IonPyBytes(CLOB) |
+        |-------------------+-------------------|
+        | blob              |  IonPyBytes(BLOB) |
+        |-------------------+-------------------|
+        | list              |   IonPyList(LIST) |
+        |-------------------+-------------------|
+        | sexp              |   IonPyList(SEXP) |
+        |-------------------+-------------------|
+        | struct            |     IonPyDict     |
+        +-------------------+-------------------+
+
+    Args:
+        fp (BaseIO): A file-like object containing Ion data.
+        catalog (Optional[SymbolTableCatalog]): The catalog to use for resolving symbol table imports.
+        single_value (Optional[True|False]): When True, the data in ``obj`` is interpreted as a single Ion value, and
+            will be returned without an enclosing container. If True and there are multiple top-level values in the Ion
+            stream, IonException will be raised. NOTE: this means that when data is dumped using
+            ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
+        encoding: NOT IMPLEMENTED
+        cls: NOT IMPLEMENTED
+        object_hook: NOT IMPLEMENTED
+        parse_float: NOT IMPLEMENTED
+        parse_int: NOT IMPLEMENTED
+        parse_constant: NOT IMPLEMENTED
+        object_pairs_hook: NOT IMPLEMENTED
+        use_decimal: NOT IMPLEMENTED
+        **kw: NOT IMPLEMENTED
+
+    Returns (Any):
+        if single_value is True:
+            A Python object representing a single Ion value.
+        else:
+            A sequence of Python objects representing a stream of Ion values.
+    """
     reader = blocking_reader(managed_reader(raw_reader(), catalog), fp)
     out = []  # top-level
     _load(out, reader)
@@ -131,7 +270,7 @@ def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object
     return out
 
 
-_TYPE_TABLE = [
+_FROM_ION_TYPE = [
     IonPyNull,
     IonPyBool,
     IonPyInt,
@@ -161,18 +300,19 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
     while event.event_type is not end_type:
         ion_type = event.ion_type
         if event.event_type is IonEventType.CONTAINER_START:
-            container = _TYPE_TABLE[ion_type].from_event(event)
+            container = _FROM_ION_TYPE[ion_type].from_event(event)
             _load(container, reader, IonEventType.CONTAINER_END, ion_type is IonType.STRUCT)
             add(container)
         elif event.event_type is IonEventType.SCALAR:
             if event.value is None or ion_type is IonType.NULL or event.ion_type.is_container:
                 scalar = IonPyNull.from_event(event)
             else:
-                scalar = _TYPE_TABLE[ion_type].from_event(event)
+                scalar = _FROM_ION_TYPE[ion_type].from_event(event)
             add(scalar)
         event = reader.send(NEXT_EVENT)
 
 
 def loads(fp, encoding='utf-8', cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None,
           object_pairs_hook=None, use_decimal=None, **kw):
+    """Not yet implemented"""
     raise IonException("Not yet implemented")

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -11,220 +11,97 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
-#
-# MIT License
-# ===========
-#
-# Copyright (c) 2006 Bob Ippolito
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is furnished to do
-# so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# Academic Free License v. 2.1
-# ============================
-#
-# Copyright (c) 2006 Bob Ippolito.  All rights reserved.
-#
-# This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose
-# owner (the "Licensor") has placed the following notice immediately following the copyright notice for the Original
-# Work:
-#
-# Licensed under the Academic Free License version 2.1
-#
-# 1) Grant of Copyright License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual,
-# sublicenseable license to do the following:
-#
-# a) to reproduce the Original Work in copies;
-#
-# b) to prepare derivative works ("Derivative Works") based upon the Original Work;
-#
-# c) to distribute copies of the Original Work and Derivative Works to the public;
-#
-# d) to perform the Original Work publicly; and
-#
-# e) to display the Original Work publicly.
-#
-# 2) Grant of Patent License. Licensor hereby grants You a world-wide, royalty-free, non-exclusive, perpetual,
-# sublicenseable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work
-# as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and Derivative Works.
-#
-# 3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making
-# modifications to it and all available documentation describing how to modify the Original Work. Licensor hereby agrees
-# to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work
-# that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy
-# of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by
-# You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that
-# information repository in a notice immediately following the copyright notice that applies to the Original Work.
-#
-# 4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original
-# Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this
-# Original Work without express prior written permission of the Licensor. Nothing in this License shall be deemed to
-# grant any rights to trademarks, copyrights, patents, trade secrets or any other intellectual property of Licensor
-# except as expressly stated herein. No patent license is granted to make, use, sell or offer to sell embodiments of any
-# patent claims other than the licensed claims defined in Section 2. No right is granted to the trademarks of Licensor
-# even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit
-# Licensor from licensing under different terms from this License any Original Work that Licensor otherwise would have a
-# right to license.
-#
-# 5) This section intentionally omitted.
-#
-# 6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright,
-# patent or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any
-# descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative
-# Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have
-# modified the Original Work.
-#
-# 7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work
-# and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms
-# of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly
-# stated in the immediately proceeding sentence, the Original Work is provided under this License on an "AS IS" BASIS
-# and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of NON-INFRINGEMENT,
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH
-# YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to Original Work is granted
-# hereunder except under this disclaimer.
-#
-# 8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence),
-# contract, or otherwise, shall the Licensor be liable to any person for any direct, indirect, special, incidental, or
-# consequential damages of any character arising as a result of this License or the use of the Original Work including,
-# without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other
-# commercial damages or losses. This limitation of liability shall not apply to liability for death or personal injury
-# resulting from Licensor's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not
-# allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not
-# apply to You.
-#
-# 9) Acceptance and Termination. If You distribute copies of the Original Work or a Derivative Work, You must make a
-# reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License.
-# Nothing else but this License (or another written agreement between Licensor and You) grants You permission to create
-# Derivative Works based upon the Original Work or to exercise any of the rights granted in Section 1 herein, and any
-# attempt to do so except under the terms of this License (or another written agreement between Licensor and You) is
-# expressly prohibited by U.S. copyright law, the equivalent laws of other countries, and by international treaty.
-# Therefore, by exercising any of the rights granted to You in Section 1 herein, You indicate Your acceptance of this
-# License and all of its terms and conditions.
-#
-# 10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of
-# the rights granted to You by this License as of the date You commence an action, including a cross-claim or
-# counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination
-# provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other
-# software or hardware.
-#
-# 11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the
-# courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under
-# the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations
-# Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work
-# outside the scope of this License or after its termination shall be subject to the requirements and penalties of the
-# U.S. Copyright Act, 17 U.S.C. § 101 et seq., the equivalent laws of other countries, and international treaty. This
-# section shall survive the termination of this License.
-#
-# 12) Attorneys Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the
-# prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable
-# attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section
-# shall survive the termination of this License.
-#
-# 13) Miscellaneous. This License represents the complete agreement concerning the subject matter hereof. If any
-# provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary
-# to make it enforceable.
-#
-# 14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an
-# individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal
-# entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes
-# of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such
-# entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares,
-# or (iii) beneficial ownership of such entity.
-#
-# 15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or
-# by law, and Licensor promises not to interfere with or be responsible for such uses by You.
-#
-# This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby granted to copy
-# and distribute this license without modification. This license may not be modified without the express written
-# permission of its copyright owner.
 
-"""Provides a ``simplejson``-like API for dumping and loading Ion data.
-
-Because certain parts of this module are derived from simplejson, this file includes the license notices (MIT and
-AFL v2.1) from simplejson.
-"""
+"""Provides a ``simplejson``-like API for dumping and loading Ion data."""
 
 # Python 2/3 compatibility
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from datetime import datetime
+from decimal import Decimal
+
 import six
 
-from amazon.ion.core import IonEvent, IonEventType, IonType, ION_STREAM_END_EVENT
-from amazon.ion.exceptions import IonException
-from amazon.ion.reader import blocking_reader, NEXT_EVENT
-from amazon.ion.reader_binary import raw_reader
-from amazon.ion.reader_managed import managed_reader
-from amazon.ion.simple_types import IonPyList, IonPyDict, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, IonPyDecimal, \
-    IonPyTimestamp, IonPyText, IonPyBytes, _IonNature
-from amazon.ion.writer import blocking_writer
-from amazon.ion.writer_binary import binary_writer
+from .core import IonEvent, IonEventType, IonType, ION_STREAM_END_EVENT
+from .exceptions import IonException
+from .reader import blocking_reader, NEXT_EVENT
+from .reader_binary import raw_reader
+from .reader_managed import managed_reader
+from .simple_types import IonPyList, IonPyDict, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, IonPyDecimal, \
+    IonPyTimestamp, IonPyText, IonPyBytes, _IonNature, IonPySymbol
+from .symbols import SymbolToken
+from .writer import blocking_writer
+from .writer_binary import binary_writer
 
 
 _ION_CONTAINER_END_EVENT = IonEvent(IonEventType.CONTAINER_END)
 
 
-def dump(obj, fp, imports=None, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
+def dump(obj, fp, imports=None, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
          separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
          tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
          ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
     writer = blocking_writer(binary_writer(imports), fp)
-    _dump(obj, writer)
+    if sequence_as_stream and isinstance(obj, (list, tuple)):
+        # Treat this top-level sequence as a stream; serialize its elements as top-level values, but don't serialize the
+        # sequence itself.
+        for top_level in obj:
+            _dump(top_level, writer)
+    else:
+        _dump(obj, writer)
     writer.send(ION_STREAM_END_EVENT)
 
 
 def _dump(obj, writer, field=None):
-    event = None
     if obj is None:
         event = IonEvent(IonEventType.SCALAR, IonType.NULL, field_name=field)
     elif obj is True:
         event = IonEvent(IonEventType.SCALAR, IonType.BOOL, True, field_name=field)
     elif obj is False:
         event = IonEvent(IonEventType.SCALAR, IonType.BOOL, False, field_name=field)
-    elif isinstance(obj, _IonNature):
-        if isinstance(obj, dict) or isinstance(obj, list):
+    elif isinstance(obj, dict):
+        if isinstance(obj, _IonNature):
             event = obj.to_event(IonEventType.CONTAINER_START, field_name=field)
         else:
-            event = obj.to_event(IonEventType.SCALAR, field_name=field)
-    elif isinstance(obj, six.integer_types):
-        event = IonEvent(IonEventType.SCALAR, IonType.INT, obj, field_name=field)
-    elif isinstance(obj, float):
-        event = IonEvent(IonEventType.SCALAR, IonType.FLOAT, obj, field_name=field)
-    elif isinstance(obj, six.text_type):
-        event = IonEvent(IonEventType.SCALAR, IonType.STRING, obj, field_name=field)
-
-    if isinstance(obj, dict):
-        if event is None:
             event = IonEvent(IonEventType.CONTAINER_START, IonType.STRUCT, field_name=field)
         writer.send(event)
         for field, val in six.iteritems(obj):
             _dump(val, writer, field)
-        writer.send(IonEvent(IonEventType.CONTAINER_END))
+        event = _ION_CONTAINER_END_EVENT
     elif isinstance(obj, list):
-        if event is None:
+        if isinstance(obj, _IonNature):
+            event = obj.to_event(IonEventType.CONTAINER_START, field_name=field)
+        else:
             event = IonEvent(IonEventType.CONTAINER_START, IonType.LIST, field_name=field)
         writer.send(event)
         for elem in obj:
             _dump(elem, writer)
-        writer.send(IonEvent(IonEventType.CONTAINER_END))
+        event = _ION_CONTAINER_END_EVENT
     else:
-        writer.send(event)
+        # obj is a scalar value
+        if isinstance(obj, _IonNature):
+            event = obj.to_event(IonEventType.SCALAR, field_name=field)
+        else:
+            if isinstance(obj, six.integer_types):
+                ion_type = IonType.INT
+            elif isinstance(obj, float):
+                ion_type = IonType.FLOAT
+            elif isinstance(obj, six.text_type):
+                ion_type = IonType.STRING
+            elif isinstance(obj, Decimal):
+                ion_type = IonType.DECIMAL
+            elif isinstance(obj, datetime):
+                ion_type = IonType.TIMESTAMP
+            elif isinstance(obj, six.binary_type):
+                ion_type = IonType.BLOB
+            elif isinstance(obj, SymbolToken):
+                ion_type = IonType.SYMBOL
+            else:
+                raise ValueError('Unknown scalar type %r' % (type(obj),))
+            event = IonEvent(IonEventType.SCALAR, ion_type, obj, field_name=field)
+    writer.send(event)
 
 
 def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
@@ -234,7 +111,7 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan
     raise IonException("Not yet implemented")
 
 
-def load(fp, catalog=None, single_value=False, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
+def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, **kw):
     reader = blocking_reader(managed_reader(raw_reader(), catalog), fp)
     out = []  # top-level
@@ -270,7 +147,7 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
             else:
                 raise ValueError("Illegal IonType for %r: %r " % (event.event_type, event.ion_type))
         elif event.event_type is IonEventType.SCALAR:
-            if event.ion_type is IonType.NULL:
+            if event.value is None or event.ion_type is IonType.NULL or event.ion_type.is_container:
                 add(IonPyNull.from_event(event))
             elif event.ion_type is IonType.BOOL:
                 add(IonPyBool.from_event(event))
@@ -282,8 +159,10 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
                 add(IonPyDecimal.from_event(event))
             elif event.ion_type is IonType.TIMESTAMP:
                 add(IonPyTimestamp.from_event(event))
-            elif event.ion_type is IonType.SYMBOL or event.ion_type is IonType.STRING:
+            elif event.ion_type is IonType.STRING:
                 add(IonPyText.from_event(event))
+            elif event.ion_type is IonType.SYMBOL:
+                add(IonPySymbol.from_event(event))
             elif event.ion_type is IonType.BLOB or event.ion_type is IonType.CLOB:
                 add(IonPyBytes.from_event(event))
             else:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -18,12 +18,15 @@ from __future__ import division
 from __future__ import print_function
 
 import sys
+import traceback
 
 _IMPORT_ALL = None
 try:
     from amazon.ion import *
 except:
+    traceback.print_exc()
     _IMPORT_ALL = sys.exc_info()
+
 
 def test_import_all():
     assert _IMPORT_ALL is None

--- a/tests/test_reader_managed.py
+++ b/tests/test_reader_managed.py
@@ -192,11 +192,13 @@ def _create_lst_params(
                 (NEXT, e_symbol(_sid(10))),
                 (NEXT, e_symbol(_sid(11))),
                 (NEXT, e_symbol(_sid(12))),
+                (NEXT, e_symbol(None)),
             ],
             outer=[
                 (NEXT, e_symbol(_tok(u'a', 10))),
                 (NEXT, e_symbol(_tok(u'b', 11))),
                 (NEXT, e_symbol(_tok(u'c', 12))),
+                (NEXT, e_symbol(None)),
             ],
         ),
         _P(

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -1,0 +1,107 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Python 2/3 compatibility
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from datetime import datetime
+from decimal import Decimal
+
+from tests import parametrize, listify
+from tests.event_aliases import *
+
+from amazon.ion.core import Timestamp, TimestampPrecision
+from amazon.ion.util import record
+from amazon.ion.symbols import SymbolToken
+from amazon.ion.simple_types import is_null, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
+                                    IonPyDecimal, IonPyTimestamp, IonPyText, IonPyBytes, \
+                                    IonPyList, IonPyDict
+
+_TEST_FIELD_NAME = SymbolToken('foo', 10)
+_TEST_ANNOTATIONS = (SymbolToken('bar', 11),)
+
+
+class _P(record('desc', 'type', 'event')):
+    def __str__(self):
+        return self.desc
+
+
+_EVENT_TYPES = [
+    (IonPyNull, e_null()),
+    (IonPyNull, e_int(None)),
+    (IonPyBool, e_bool(True)),
+    (IonPyInt, e_int(65000)),
+    (IonPyInt, e_int(2 ** 64 + 1)),
+    (IonPyFloat, e_float(1e0)),
+    (IonPyDecimal, e_decimal(Decimal('1.1'))),
+    (IonPyTimestamp, e_timestamp(datetime(2012, 1, 1))),
+    (IonPyTimestamp, e_timestamp(Timestamp(2012, 1, 1, precision=TimestampPrecision.DAY))),
+    (IonPyText, e_string(u'Hello')),
+    (IonPyBytes, e_clob(b'Goodbye')),
+
+    # Technically this is not how we shape the event, but the container types don't care
+    (IonPyList, e_start_sexp([1, 2, 3])),
+    (IonPyDict, e_start_struct({u'hello': u'world'}))
+]
+
+
+@listify
+def event_type_parameters():
+    for cls, event in _EVENT_TYPES:
+        yield _P(
+            desc='EVENT TO %s - %s - %r' % (cls.__name__, event.ion_type.name, event.value),
+            type=cls,
+            event=event.derive_annotations(_TEST_ANNOTATIONS).derive_field_name(_TEST_FIELD_NAME)
+        )
+
+
+@parametrize(*event_type_parameters())
+def test_event_types(p):
+    value = p.event.value
+    ion_type = p.event.ion_type
+
+    event_output = p.type.from_event(p.event)
+    value_output = p.type.from_value(ion_type, value, tuple(x.text for x in p.event.annotations))
+
+    if p.type is IonPyNull:
+        # Null is a special case due to the non-extension of NoneType.
+        assert not event_output
+        assert not value_output
+        assert is_null(event_output)
+        assert is_null(value_output)
+        assert event_output == value_output
+    else:
+        # Make sure we don't change value equality symmetry.
+        assert event_output == value
+        assert value == event_output
+
+        assert value_output == value
+        assert value == value_output
+
+        # Derive a new event from just the value because equality is stricter in some cases.
+        value_event = e_scalar(ion_type, value)
+        output_event = e_scalar(ion_type, event_output)
+        assert value_event == output_event
+
+    annotation_texts = tuple(x.text for x in p.event.annotations)
+
+    assert event_output.ion_event == p.event
+    assert event_output.ion_type is ion_type
+    assert annotation_texts == event_output.ion_annotations
+
+    assert value_output.ion_event is None
+    assert value_output.ion_type is ion_type
+    assert annotation_texts == value_output.ion_annotations

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -24,7 +24,7 @@ from amazon.ion.writer_binary import _IVM
 from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol, _IonNature
-from amazon.ion.simpleion import dump, load, _ion_type, _TYPE_TABLE
+from amazon.ion.simpleion import dump, load, _ion_type, _FROM_ION_TYPE
 from amazon.ion.util import record
 from amazon.ion.writer_binary_raw import _serialize_symbol, _write_length
 from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP
@@ -136,7 +136,7 @@ def generate_scalars(scalars_map, preceding_symbols=0):
                 yield Parameter(IonType.SYMBOL.name + ' ' + native,
                                 IonPyText.from_value(IonType.SYMBOL, native), symbol_expected, True)
             yield Parameter(ion_type.name + ' ' + str(native), native, native_expected, has_symbols)
-            wrapper = _TYPE_TABLE[ion_type].from_value(ion_type, native)  # TODO add some annotations
+            wrapper = _FROM_ION_TYPE[ion_type].from_value(ion_type, native)  # TODO add some annotations
             yield Parameter(repr(wrapper), wrapper, expected, has_symbols)
 
 
@@ -276,15 +276,15 @@ def _generate_roundtrips(roundtrips):
         yield obj
         if not isinstance(obj, _IonNature):
             ion_type = _ion_type(obj)
-            yield _TYPE_TABLE[ion_type].from_value(ion_type, obj)
+            yield _FROM_ION_TYPE[ion_type].from_value(ion_type, obj)
         else:
             ion_type = obj.ion_type
         if isinstance(obj, IonPyNull):
             obj = None
-        yield _TYPE_TABLE[ion_type].from_value(ion_type, obj, annotations=('annot1', 'annot2'))
+        yield _FROM_ION_TYPE[ion_type].from_value(ion_type, obj, annotations=('annot1', 'annot2'))
         if isinstance(obj, list):
-            yield _TYPE_TABLE[ion_type].from_value(IonType.SEXP, obj)
-            yield _TYPE_TABLE[ion_type].from_value(IonType.SEXP, obj, annotations=('annot1', 'annot2'))
+            yield _FROM_ION_TYPE[ion_type].from_value(IonType.SEXP, obj)
+            yield _FROM_ION_TYPE[ion_type].from_value(IonType.SEXP, obj, annotations=('annot1', 'annot2'))
 
 
 def _assert_roundtrip(before, after):
@@ -294,7 +294,7 @@ def _assert_roundtrip(before, after):
         out = obj
         if not isinstance(out, _IonNature):
             ion_type = _ion_type(out)
-            out = _TYPE_TABLE[ion_type].from_value(ion_type, out)
+            out = _FROM_ION_TYPE[ion_type].from_value(ion_type, out)
         if isinstance(out, dict):
             update = {}
             for field, value in six.iteritems(out):

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -18,7 +18,9 @@ from decimal import Decimal
 from itertools import chain
 
 import six
+from pytest import raises
 
+from amazon.ion.exceptions import IonException
 from amazon.ion.symbols import SymbolToken
 from amazon.ion.writer_binary import _IVM
 from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
@@ -318,3 +320,19 @@ def test_roundtrip(obj):
     out.seek(0)
     res = load(out)
     _assert_roundtrip(obj, res)
+
+
+def test_single_value_with_stream_fails():
+    out = BytesIO()
+    dump(['foo', 123], out, sequence_as_stream=True)
+    out.seek(0)
+    with raises(IonException):
+        load(out, single_value=True)
+
+
+def test_unknown_object_type_fails():
+    class Dummy:
+        pass
+    out = BytesIO()
+    with raises(TypeError):
+        dump(Dummy(), out)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -11,6 +11,7 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from datetime import datetime, timedelta
 from io import BytesIO
 
 from decimal import Decimal
@@ -18,12 +19,14 @@ from itertools import chain
 
 import six
 
+from amazon.ion.symbols import SymbolToken
 from amazon.ion.writer_binary import _IVM
-from amazon.ion.core import IonType
+from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
-    IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol
-from amazon.ion.simpleion import dump, load
+    IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol, _IonNature
+from amazon.ion.simpleion import dump, load, _ion_type
 from amazon.ion.util import record
+from amazon.ion.writer_binary_raw import _serialize_symbol, _write_length
 from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP
 from tests import parametrize
 
@@ -43,57 +46,91 @@ _TYPE_TABLE = [
     IonPyText,
     IonPyBytes,
     IonPyBytes,
-    IonPyDict,
     IonPyList,
-    IonPyList
+    IonPyList,
+    IonPyDict
 ]
 
 _SIMPLE_CONTAINER_MAP = {
     IonType.LIST: (
         (
-            ([],),
-            b'\xB0'
+            [[], ],
+            [b'\xB0', ]
         ),
         (
-            ([0],),
-            bytearray([
-                0xB0 | 0x01,  # Int value 0 fits in 1 byte.
-                ION_ENCODED_INT_ZERO
-            ])
+            [IonPyList.from_value(IonType.LIST, []), ],
+            [b'\xB0', ]
+        ),
+        (
+            [[0], ],
+            [
+                bytearray([
+                    0xB0 | 0x01,  # Int value 0 fits in 1 byte.
+                    ION_ENCODED_INT_ZERO
+                ]),
+            ]
+        ),
+        (
+            [IonPyList.from_value(IonType.LIST, [0]), ],
+            [
+                bytearray([
+                    0xB0 | 0x01,  # Int value 0 fits in 1 byte.
+                    ION_ENCODED_INT_ZERO
+                ]),
+            ]
         ),
     ),
     IonType.SEXP: (
         (
-            (IonPyList.from_value(IonType.SEXP, []),),
-            b'\xC0'
+            [IonPyList.from_value(IonType.SEXP, []), ],
+            [b'\xC0', ]
         ),
         (
-            (IonPyList.from_value(IonType.SEXP, [0]),),
-            bytearray([
-                0xC0 | 0x01,  # Int value 0 fits in 1 byte.
-                ION_ENCODED_INT_ZERO
-            ])
+            [IonPyList.from_value(IonType.SEXP, [0]), ],
+            [
+                bytearray([
+                    0xC0 | 0x01,  # Int value 0 fits in 1 byte.
+                    ION_ENCODED_INT_ZERO
+                ]),
+            ]
         ),
     ),
     IonType.STRUCT: (
         (
-            ({},),
-            b'\xD0'
+            [{}, ],
+            [b'\xD0', ]
         ),
         (
-            ({u'foo': 0},),
-            bytearray([
-                0xDE,  # The lower nibble may vary by implementation. It does not indicate actual length unless it's 0.
-                VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
-                VARUINT_END_BYTE | 10,
-                ION_ENCODED_INT_ZERO
-            ])
+            [IonPyDict.from_value(IonType.STRUCT, {}), ],
+            [b'\xD0', ]
+        ),
+        (
+            [{u'foo': 0}, ],
+            [
+                bytearray([
+                    0xDE,  # The lower nibble may vary. It does not indicate actual length unless it's 0.
+                    VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
+                    VARUINT_END_BYTE | 10,
+                    ION_ENCODED_INT_ZERO
+                ]),
+            ]
+        ),
+        (
+            [IonPyDict.from_value(IonType.STRUCT, {u'foo': 0}), ],
+            [
+                bytearray([
+                    0xDE,  # The lower nibble may vary. It does not indicate actual length unless it's 0.
+                    VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
+                    VARUINT_END_BYTE | 10,
+                    ION_ENCODED_INT_ZERO
+                ]),
+            ]
         ),
     ),
 }
 
 
-def generate_scalars(scalars_map):
+def generate_scalars(scalars_map, preceding_symbols=0):
     for ion_type, values in six.iteritems(scalars_map):
         for native, expected in values:
             native_expected = expected
@@ -108,45 +145,67 @@ def generate_scalars(scalars_map):
             elif ion_type is IonType.SYMBOL and native is not None:
                 has_symbols = True
             elif ion_type is IonType.STRING:
-                # Encode all strings as symbols too. Since they're encoded as individual values, all will have SID 10
-                yield Parameter(IonType.SYMBOL.name + ' ' + native, IonPyText.from_value(IonType.SYMBOL, native), b'\x71\x0a', True)
+                # Encode all strings as symbols too.
+                symbol_expected = _serialize_symbol(
+                    IonEvent(IonEventType.SCALAR, IonType.SYMBOL, SymbolToken(None, 10 + preceding_symbols)))
+                yield Parameter(IonType.SYMBOL.name + ' ' + native,
+                                IonPyText.from_value(IonType.SYMBOL, native), symbol_expected, True)
             yield Parameter(ion_type.name + ' ' + str(native), native, native_expected, has_symbols)
             wrapper = _TYPE_TABLE[ion_type].from_value(ion_type, native)  # TODO add some annotations
             yield Parameter(repr(wrapper), wrapper, expected, has_symbols)
 
 
-def generate_containers(container_map):
+def generate_containers(container_map, preceding_symbols=0):
     for ion_type, container in six.iteritems(container_map):
         for test_tuple in container:
             obj = test_tuple[0]
-            encoded = test_tuple[1]
+            expecteds = test_tuple[1]
             has_symbols = False
             for elem in obj:
                 if isinstance(elem, dict) and len(elem) > 0:
                     has_symbols = True
-            yield Parameter(IonType.SYMBOL.name + ' ' + repr(obj), obj, encoded, has_symbols, True)
+            if has_symbols and preceding_symbols:
+                for expected in expecteds:
+                    field_sid = expected[-2] & (~VARUINT_END_BYTE)
+                    expected[-2] = VARUINT_END_BYTE | (preceding_symbols + field_sid)
+            yield Parameter(IonType.SYMBOL.name + ' ' + repr(obj), obj, b''.join(expecteds), has_symbols, True)
 
 
-def test_roundtrip():
-    sym = IonPyText.from_value(IonType.SYMBOL, 'sym')
-    bar = IonPyText.from_value(IonType.STRING, 'bar', annotations=('str',))
-    lst = IonPyList.from_value(IonType.LIST, [True, None, 1.23e4, sym])
-    sxp = IonPyList.from_value(IonType.SEXP, [False, IonPyNull.from_value(IonType.STRUCT, None, ('class',)), Decimal('5.678')])
-    dct = IonPyDict.from_value(IonType.STRUCT, {"foo": bar, "baz": 123, "lst": lst, "sxp": sxp}, annotations=('annot1', 'annot2'))
-    out = BytesIO()
-    dump(dct, out)
-    out.seek(0)
-    res = load(out)
-    print("%r" % (res,))
-
+def generate_annotated_values(scalars_map, container_map):
+    for value_p in chain(generate_scalars(scalars_map, preceding_symbols=2),
+                         generate_containers(container_map, preceding_symbols=2)):
+        obj = value_p.obj
+        if not isinstance(obj, _IonNature):
+            continue
+        obj.ion_annotations = (SymbolToken(u'annot1', None), SymbolToken(u'annot2', None),)
+        annot_length = 2  # 10 and 11 each fit in one VarUInt byte
+        annot_length_length = 1  # 2 fits in one VarUInt byte
+        value_length = len(value_p.expected)
+        length_field = annot_length + annot_length_length + value_length
+        wrapper = []
+        _write_length(wrapper, length_field, 0xE0)
+        wrapper.extend([
+            VARUINT_END_BYTE | annot_length,
+            VARUINT_END_BYTE | 10,
+            VARUINT_END_BYTE | 11
+        ])
+        yield Parameter(
+            desc='ANNOTATED %s' % value_p.desc,
+            obj=obj,
+            expected=bytearray(wrapper) + value_p.expected,
+            has_symbols=True,
+            stream=value_p.stream
+        )
 
 @parametrize(
     *tuple(chain(
         generate_scalars(SIMPLE_SCALARS_MAP),
-        generate_containers(_SIMPLE_CONTAINER_MAP)
+        generate_containers(_SIMPLE_CONTAINER_MAP),
+        generate_annotated_values(SIMPLE_SCALARS_MAP, _SIMPLE_CONTAINER_MAP),
     ))
 )
-def test_scalars_dump(p):
+def test_dump_load(p):
+    # test dump
     out = BytesIO()
     dump(p.obj, out, sequence_as_stream=p.stream)
     res = out.getvalue()
@@ -155,19 +214,122 @@ def test_scalars_dump(p):
     else:
         # The payload contains a LST. The value comes last, so compare the end bytes.
         assert p.expected == res[len(res) - len(p.expected):]
-
-
-@parametrize(
-    *tuple(chain(
-        generate_scalars(SIMPLE_SCALARS_MAP)
-    ))
-)
-def test_scalars_load(p):
-    out = BytesIO()
-    dump(p.obj, out)
+    # test load
     out.seek(0)
-    res = load(out)
+    res = load(out, single_value=(not p.stream))
     if p.obj is None:
         assert isinstance(res, IonPyNull)
     else:
         assert p.obj == res
+
+
+_ROUNDTRIPS = [
+    None,
+    IonPyNull.from_value(IonType.NULL, None),
+    IonPyNull.from_value(IonType.BOOL, None),
+    IonPyNull.from_value(IonType.INT, None),
+    IonPyNull.from_value(IonType.FLOAT, None),
+    IonPyNull.from_value(IonType.DECIMAL, None),
+    IonPyNull.from_value(IonType.TIMESTAMP, None),
+    IonPyNull.from_value(IonType.SYMBOL, None),
+    IonPyNull.from_value(IonType.STRING, None),
+    IonPyNull.from_value(IonType.CLOB, None),
+    IonPyNull.from_value(IonType.BLOB, None),
+    IonPyNull.from_value(IonType.LIST, None),
+    IonPyNull.from_value(IonType.SEXP, None),
+    IonPyNull.from_value(IonType.STRUCT, None),
+    True,
+    False,
+    IonPyInt.from_value(IonType.BOOL, 0),
+    IonPyInt.from_value(IonType.BOOL, 1),
+    0,
+    -1,
+    1.23,
+    1.23e4,
+    -1.23,
+    -1.23e-4,
+    Decimal(0),
+    Decimal('-1.23'),
+    datetime(year=1, month=1, day=1, tzinfo=OffsetTZInfo(timedelta(minutes=-1))),
+    u'',
+    u'abc',
+    u'abcdefghijklmno',
+    u'a\U0001f4a9c',
+    u'a\u0009\x0a\x0dc',
+    b'abcd',
+    IonPyBytes.from_value(IonType.CLOB, b'abcd'),
+    [[[]]],
+    [[],[],[]],
+    [{}, {}, {}],
+    {'foo': [], 'bar': [], 'baz': []},
+    {'foo': {'foo': {}}},
+    [{'foo': [{'foo': []}]}],
+    {'foo': [{'foo': []}]},
+    {
+         "foo": IonPyText.from_value(IonType.STRING, 'bar', annotations=('str',)),
+         "baz": 123,
+         "lst": IonPyList.from_value(IonType.LIST,
+                                     [
+                                         True,
+                                         None,
+                                         1.23e4,
+                                         IonPyText.from_value(IonType.SYMBOL, 'sym')
+                                     ]),
+         "sxp": IonPyList.from_value(IonType.SEXP,
+                                     [
+                                         False,
+                                         IonPyNull.from_value(IonType.STRUCT, None, ('class',)),
+                                         Decimal('5.678')
+                                     ])
+    },
+
+]
+
+
+def _generate_roundtrips(roundtrips):
+    for obj in roundtrips:
+        yield obj
+        if not isinstance(obj, _IonNature):
+            ion_type = _ion_type(obj)
+            yield _TYPE_TABLE[ion_type].from_value(ion_type, obj)
+        else:
+            ion_type = obj.ion_type
+        if isinstance(obj, IonPyNull):
+            obj = None
+        yield _TYPE_TABLE[ion_type].from_value(ion_type, obj, annotations=('annot1', 'annot2'))
+        if isinstance(obj, list):
+            yield _TYPE_TABLE[ion_type].from_value(IonType.SEXP, obj)
+            yield _TYPE_TABLE[ion_type].from_value(IonType.SEXP, obj, annotations=('annot1', 'annot2'))
+
+
+def _assert_roundtrip(before, after):
+    # All loaded Ion values extend _IonNature, even if they were dumped from primitives. This recursively
+    # wraps each input value in _IonNature for comparison against the output.
+    def _to_ion_nature(obj):
+        out = obj
+        if not isinstance(out, _IonNature):
+            ion_type = _ion_type(out)
+            out = _TYPE_TABLE[ion_type].from_value(ion_type, out)
+        if isinstance(out, dict):
+            update = {}
+            for field, value in six.iteritems(out):
+                update[field] = _to_ion_nature(value)
+            out = update
+        elif isinstance(out, list):
+            update = []
+            for value in out:
+                update.append(_to_ion_nature(value))
+            out = update
+        return out
+    assert _to_ion_nature(before) == after
+
+
+@parametrize(
+    *tuple(_generate_roundtrips(_ROUNDTRIPS))
+)
+def test_roundtrip(obj):
+    out = BytesIO()
+    dump(obj, out)
+    out.seek(0)
+    res = load(out)
+    _assert_roundtrip(obj, res)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -24,7 +24,7 @@ from amazon.ion.writer_binary import _IVM
 from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol, _IonNature
-from amazon.ion.simpleion import dump, load, _ion_type
+from amazon.ion.simpleion import dump, load, _ion_type, _TYPE_TABLE
 from amazon.ion.util import record
 from amazon.ion.writer_binary_raw import _serialize_symbol, _write_length
 from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP
@@ -35,21 +35,6 @@ class Parameter(record('desc', 'obj', 'expected', 'has_symbols', ('stream', Fals
     def __str__(self):
         return self.desc
 
-_TYPE_TABLE = [
-    IonPyNull,
-    IonPyBool,
-    IonPyInt,
-    IonPyFloat,
-    IonPyDecimal,
-    IonPyTimestamp,
-    IonPySymbol,
-    IonPyText,
-    IonPyBytes,
-    IonPyBytes,
-    IonPyList,
-    IonPyList,
-    IonPyDict
-]
 
 _SIMPLE_CONTAINER_MAP = {
     IonType.LIST: (

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -11,29 +11,19 @@
 # OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the
 # License.
+from io import BytesIO
 
-# Python 2/3 compatibility
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from amazon.ion.core import IonType
+from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList
+from amazon.ion.simpleion import dump, load
 
-__author__ = 'Amazon.com, Inc.'
-__version__ = '0.1.0'
 
-__all__ = [
-    'core',
-    'exceptions',
-    'reader',
-    'reader_binary',
-    'reader_managed',
-    'simple_types',
-    'simpleion',
-    'symbols',
-    'util',
-    'writer',
-    'writer_binary',
-    'writer_binary_raw',
-    'writer_binary_raw_fields',
-    'writer_buffer',
-    'writer_text',
-]
+def test_roundtrip():
+    bar = IonPyText.from_value(IonType.STRING, 'bar', annotations=('str',))
+    lst = IonPyList.from_value(IonType.LIST, [True, None, 1.23e4])
+    dct = IonPyDict.from_value(IonType.STRUCT, {"foo": bar, "baz": 123, "lst": lst}, annotations=('annot1', 'annot2'))
+    out = BytesIO()
+    dump(dct, out)
+    out.seek(0)
+    res = load(out)
+    print("%r" % (res,))

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -13,17 +13,161 @@
 # License.
 from io import BytesIO
 
+from decimal import Decimal
+from itertools import chain
+
+import six
+
+from amazon.ion.writer_binary import _IVM
 from amazon.ion.core import IonType
-from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList
+from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
+    IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol
 from amazon.ion.simpleion import dump, load
+from amazon.ion.util import record
+from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP
+from tests import parametrize
+
+
+class Parameter(record('desc', 'obj', 'expected', 'has_symbols', ('stream', False))):
+    def __str__(self):
+        return self.desc
+
+_TYPE_TABLE = [
+    IonPyNull,
+    IonPyBool,
+    IonPyInt,
+    IonPyFloat,
+    IonPyDecimal,
+    IonPyTimestamp,
+    IonPySymbol,
+    IonPyText,
+    IonPyBytes,
+    IonPyBytes,
+    IonPyDict,
+    IonPyList,
+    IonPyList
+]
+
+_SIMPLE_CONTAINER_MAP = {
+    IonType.LIST: (
+        (
+            ([],),
+            b'\xB0'
+        ),
+        (
+            ([0],),
+            bytearray([
+                0xB0 | 0x01,  # Int value 0 fits in 1 byte.
+                ION_ENCODED_INT_ZERO
+            ])
+        ),
+    ),
+    IonType.SEXP: (
+        (
+            (IonPyList.from_value(IonType.SEXP, []),),
+            b'\xC0'
+        ),
+        (
+            (IonPyList.from_value(IonType.SEXP, [0]),),
+            bytearray([
+                0xC0 | 0x01,  # Int value 0 fits in 1 byte.
+                ION_ENCODED_INT_ZERO
+            ])
+        ),
+    ),
+    IonType.STRUCT: (
+        (
+            ({},),
+            b'\xD0'
+        ),
+        (
+            ({u'foo': 0},),
+            bytearray([
+                0xDE,  # The lower nibble may vary by implementation. It does not indicate actual length unless it's 0.
+                VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
+                VARUINT_END_BYTE | 10,
+                ION_ENCODED_INT_ZERO
+            ])
+        ),
+    ),
+}
+
+
+def generate_scalars(scalars_map):
+    for ion_type, values in six.iteritems(scalars_map):
+        for native, expected in values:
+            native_expected = expected
+            has_symbols = False
+            if native is None:
+                # An un-adorned 'None' doesn't contain enough information to determine its Ion type
+                native_expected = b'\x0f'
+            elif ion_type is IonType.CLOB:
+                # All six.binary_type are treated as BLOBs unless wrapped by an _IonNature
+                tid = expected[0] + 0x10  # increment upper nibble for clob -> blob; keep lower nibble
+                native_expected = bytearray([tid]) + expected[1:]
+            elif ion_type is IonType.SYMBOL and native is not None:
+                has_symbols = True
+            elif ion_type is IonType.STRING:
+                # Encode all strings as symbols too. Since they're encoded as individual values, all will have SID 10
+                yield Parameter(IonType.SYMBOL.name + ' ' + native, IonPyText.from_value(IonType.SYMBOL, native), b'\x71\x0a', True)
+            yield Parameter(ion_type.name + ' ' + str(native), native, native_expected, has_symbols)
+            wrapper = _TYPE_TABLE[ion_type].from_value(ion_type, native)  # TODO add some annotations
+            yield Parameter(repr(wrapper), wrapper, expected, has_symbols)
+
+
+def generate_containers(container_map):
+    for ion_type, container in six.iteritems(container_map):
+        for test_tuple in container:
+            obj = test_tuple[0]
+            encoded = test_tuple[1]
+            has_symbols = False
+            for elem in obj:
+                if isinstance(elem, dict) and len(elem) > 0:
+                    has_symbols = True
+            yield Parameter(IonType.SYMBOL.name + ' ' + repr(obj), obj, encoded, has_symbols, True)
 
 
 def test_roundtrip():
+    sym = IonPyText.from_value(IonType.SYMBOL, 'sym')
     bar = IonPyText.from_value(IonType.STRING, 'bar', annotations=('str',))
-    lst = IonPyList.from_value(IonType.LIST, [True, None, 1.23e4])
-    dct = IonPyDict.from_value(IonType.STRUCT, {"foo": bar, "baz": 123, "lst": lst}, annotations=('annot1', 'annot2'))
+    lst = IonPyList.from_value(IonType.LIST, [True, None, 1.23e4, sym])
+    sxp = IonPyList.from_value(IonType.SEXP, [False, IonPyNull.from_value(IonType.STRUCT, None, ('class',)), Decimal('5.678')])
+    dct = IonPyDict.from_value(IonType.STRUCT, {"foo": bar, "baz": 123, "lst": lst, "sxp": sxp}, annotations=('annot1', 'annot2'))
     out = BytesIO()
     dump(dct, out)
     out.seek(0)
     res = load(out)
     print("%r" % (res,))
+
+
+@parametrize(
+    *tuple(chain(
+        generate_scalars(SIMPLE_SCALARS_MAP),
+        generate_containers(_SIMPLE_CONTAINER_MAP)
+    ))
+)
+def test_scalars_dump(p):
+    out = BytesIO()
+    dump(p.obj, out, sequence_as_stream=p.stream)
+    res = out.getvalue()
+    if not p.has_symbols:
+        assert (_IVM + p.expected) == res
+    else:
+        # The payload contains a LST. The value comes last, so compare the end bytes.
+        assert p.expected == res[len(res) - len(p.expected):]
+
+
+@parametrize(
+    *tuple(chain(
+        generate_scalars(SIMPLE_SCALARS_MAP)
+    ))
+)
+def test_scalars_load(p):
+    out = BytesIO()
+    dump(p.obj, out)
+    out.seek(0)
+    res = load(out)
+    if p.obj is None:
+        assert isinstance(res, IonPyNull)
+    else:
+        assert p.obj == res

--- a/tests/writer_util.py
+++ b/tests/writer_util.py
@@ -17,10 +17,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from datetime import datetime, timedelta
+
 import six
+from decimal import Decimal
 from pytest import raises
 
-from amazon.ion.core import ION_STREAM_END_EVENT, IonEventType, IonEvent
+from amazon.ion.core import ION_STREAM_END_EVENT, IonEventType, IonEvent, IonType, timestamp, OffsetTZInfo, \
+    TimestampPrecision
+from amazon.ion.symbols import SYMBOL_ZERO_TOKEN, SymbolToken
 from amazon.ion.util import record
 from amazon.ion.writer import WriteEventType
 from tests import is_exception
@@ -28,6 +33,8 @@ from tests import noop_manager
 
 _STREAM_END_EVENT = (ION_STREAM_END_EVENT,)
 
+ION_ENCODED_INT_ZERO = 0x20
+VARUINT_END_BYTE = 0x80
 
 class WriterParameter(record('desc', 'events', 'expected')):
     def __str__(self):
@@ -44,6 +51,129 @@ def _scalar_p(ion_type, value, expected, force_stream_end):
         expected=expected,
     )
 
+_D = Decimal
+_DT = datetime
+_IT = IonType
+
+SIMPLE_SCALARS_MAP = {
+    _IT.NULL: (
+        (None, b'\x0F'),
+    ),
+    _IT.BOOL: (
+        (None, b'\x1F'),
+        (False, b'\x10'),
+        (True, b'\x11')
+    ),
+    _IT.INT: (
+        (None, b'\x2F'),
+        (0, b'\x20'),
+        (1, b'\x21\x01'),
+        (-1, b'\x31\x01'),
+        (0xFFFFFFFF, b'\x24\xFF\xFF\xFF\xFF'),
+        (-0xFFFFFFFF, b'\x34\xFF\xFF\xFF\xFF'),
+        (0xFFFFFFFFFFFFFFFF, b'\x28\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'),
+        (-0xFFFFFFFFFFFFFFFF, b'\x38\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'),
+        (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+         b'\x2E\x90\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'),
+        (-0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+         b'\x3E\x90\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'),
+    ),
+    _IT.FLOAT: (
+        (None, b'\x4F'),
+        (0e0, b'\x40'),
+        (1e0, b'\x48\x3F\xF0\x00\x00\x00\x00\x00\x00'),
+        (-1e0, b'\x48\xBF\xF0\x00\x00\x00\x00\x00\x00'),
+        (1e1, b'\x48\x40\x24\x00\x00\x00\x00\x00\x00'),
+        (-1e1, b'\x48\xC0\x24\x00\x00\x00\x00\x00\x00'),
+        (float('inf'), b'\x48\x7F\xF0\x00\x00\x00\x00\x00\x00'),
+        (float('-inf'), b'\x48\xFF\xF0\x00\x00\x00\x00\x00\x00'),
+    ),
+    _IT.DECIMAL: (
+        (None, b'\x5F'),
+        (_D(0), b'\x50'),
+        (_D(0).copy_negate(), b'\x52\x80\x80'),
+        (_D("1e1"), b'\x52\x81\x01'),
+        (_D("1e0"), b'\x52\x80\x01'),
+        (_D("1e-1"), b'\x52\xC1\x01'),
+        (_D("0e-1"), b'\x51\xC1'),
+        (_D("0e1"), b'\x51\x81'),
+        (_D("-1e1"), b'\x52\x81\x81'),
+        (_D("-1e0"), b'\x52\x80\x81'),
+        (_D("-1e-1"), b'\x52\xC1\x81'),
+        (_D("-0e-1"), b'\x52\xC1\x80'),
+        (_D("-0e1"), b'\x52\x81\x80'),
+    ),
+    _IT.TIMESTAMP: (
+        (None, b'\x6F'),
+        # TODO Clarify whether there's a valid zero-length Timestamp representation.
+        (_DT(year=1, month=1, day=1), b'\x67\xC0\x81\x81\x81\x80\x80\x80'),
+        (_DT(year=1, month=1, day=1, tzinfo=OffsetTZInfo(timedelta(minutes=-1))),
+         b'\x67\xC1\x81\x81\x81\x80\x81\x80'),
+        (_DT(year=1, month=1, day=1, hour=0, minute=0, second=0, microsecond=1),
+         b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC6\x01'),
+        (timestamp(year=1, month=1, day=1, precision=TimestampPrecision.DAY), b'\x64\xC0\x81\x81\x81'),
+        (timestamp(year=1, month=1, day=1, off_minutes=-1, precision=TimestampPrecision.SECOND),
+         b'\x67\xC1\x81\x81\x81\x80\x81\x80'),
+        (timestamp(year=1, month=1, day=1, hour=0, minute=0, second=0, microsecond=1, precision=TimestampPrecision.SECOND),
+         b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC6\x01'),
+        (timestamp(2016, precision=TimestampPrecision.YEAR), b'\x63\xC0\x0F\xE0'),  # -00:00
+        (timestamp(2016, off_hours=0, precision=TimestampPrecision.YEAR), b'\x63\x80\x0F\xE0'),
+        (
+            timestamp(2016, 2, 1, 0, 1, off_minutes=1, precision=TimestampPrecision.MONTH),
+            b'\x64\x81\x0F\xE0\x82'
+        ),
+        (
+            timestamp(2016, 2, 1, 23, 0, off_hours=-1, precision=TimestampPrecision.DAY),
+            b'\x65\xFC\x0F\xE0\x82\x82'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, off_hours=-7, precision=TimestampPrecision.MINUTE),
+            b'\x68\x43\xA4\x0F\xE0\x82\x82\x87\x80'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, off_hours=-7, precision=TimestampPrecision.SECOND),
+            b'\x69\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, 1000, off_hours=-7, precision=TimestampPrecision.SECOND),
+            b'\x6B\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E\xC3\x01'
+        ),
+    ),
+    _IT.SYMBOL: (
+        (None, b'\x7F'),
+        (SYMBOL_ZERO_TOKEN, b'\x70'),
+        (SymbolToken(u'$ion', 1), b'\x71\x01'),
+    ),
+    _IT.STRING: (
+        (None, b'\x8F'),
+        (u'', b'\x80'),
+        (u'abc', b'\x83abc'),
+        (u'abcdefghijklmno', b'\x8E\x8Fabcdefghijklmno'),
+        (u'a\U0001f4a9c', b'\x86' + bytearray([b for b in u'a\U0001f4a9c'.encode('utf-8')])),
+        (u'a\u0009\x0a\x0dc', b'\x85' + bytearray([b for b in 'a\t\n\rc'.encode('utf-8')])),
+    ),
+    _IT.CLOB: (
+        (None, b'\x9F'),
+        (b'', b'\x90'),
+        (b'abc', b'\x93' + b'abc'),
+        (b'abcdefghijklmno', b'\x9E\x8Fabcdefghijklmno'),
+    ),
+    _IT.BLOB: (
+        (None, b'\xAF'),
+        (b'', b'\xA0'),
+        (b'abc', b'\xA3' + b'abc'),
+        (b'abcdefghijklmno', b'\xAE\x8Fabcdefghijklmno'),
+    ),
+    _IT.LIST: (
+        (None, b'\xBF'),
+    ),
+    _IT.SEXP: (
+        (None, b'\xCF'),
+    ),
+    _IT.STRUCT: (
+        (None, b'\xDF'),
+    ),
+}
 
 def generate_scalars(scalars_map, force_stream_end=False):
     for ion_type, values in six.iteritems(scalars_map):


### PR DESCRIPTION
The starting point for a simplejson-esque API which allows users to easily convert Python objects to and from Ion data (currently binary only).