### PR TITLE
Ion type algorithm now inspects entire type hierarchy

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -155,12 +155,14 @@ _FROM_TYPE = dict(chain(
 
 
 def _ion_type(obj):
-    try:
-        ion_type = _FROM_TYPE[type(obj)]
-    except KeyError:
-        raise TypeError('Unknown scalar type %r' % (type(obj),))
-    return ion_type
+    types = [type(obj)]
+    while types:
+        current_type = types.pop()
+        if current_type in _FROM_TYPE:
+            return _FROM_TYPE[current_type]
+        types.extend(current_type.__bases__)
 
+    raise TypeError('Unknown scalar type %r' % (type(obj),))
 
 def _dump(obj, writer, field=None):
     null = is_null(obj)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -94,8 +94,8 @@ def dump(obj, fp, imports=None, sequence_as_stream=False, skipkeys=False, ensure
         +-------------------+-------------------+
 
     Args:
-        obj (Any): A python object to serialize according to the above table. Any Python types encountered in the object
-             not present in the above table will raise TypeError.
+        obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
+            instance of or inherits from one of the types in the above table will raise TypeError.
         fp (BaseIO): A file-like object.
         imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
         sequence_as_stream (Optional[True|False]): When True, if ``obj`` is a sequence, it will be treated as a stream

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -29,6 +29,7 @@ from amazon.ion.symbols import SymbolToken
 from amazon.ion.simple_types import is_null, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
                                     IonPyDecimal, IonPyTimestamp, IonPyText, IonPyBytes, \
                                     IonPyList, IonPyDict, IonPySymbol
+from amazon.ion.simpleion import _ion_type
 
 _TEST_FIELD_NAME = SymbolToken('foo', 10)
 _TEST_ANNOTATIONS = (SymbolToken('bar', 11),)
@@ -106,3 +107,9 @@ def test_event_types(p):
     assert value_output.ion_event is to_event_output
     assert value_output.ion_type is ion_type
     assert p.event.annotations == value_output.ion_annotations
+
+def test_subclass_types():
+    class Foo(dict):
+        pass
+
+    assert _ion_type(Foo()) is IonType.STRUCT


### PR DESCRIPTION
Previously the algorithm would fail given a subclass of any supported class