### PR TITLE
Bumping to post-release version to get around PyPI upload error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='amazon.ion',
-    version='0.1.0',
+    version='0.1.0post1',
     description='A Python implementation of Amazon Ion.',
     url='http://github.com/amznlabs/ion-python',
     author='Amazon Ion Team',


### PR DESCRIPTION
Using twine from the command line to upload the source distribution did -not- include the signature (.asc) file, and it cannot be added by itself either via the command line or the PyPI website. The "solution" is to do a post-release minor version bump to change the base file name of the release so that it doesn't conflict with the previous "dead" release. See also:

User complaints about PyPI's inability to re-upload identical files:

https://github.com/pypa/packaging-problems/issues/74

StackOverflow discussion of the same issue:

http://stackoverflow.com/questions/28708705/pypi-400-upload-error/28874414

Acceptable versioning schemes (with examples of .postX):

https://packaging.python.org/distributing/#choosing-a-versioning-scheme
