### PR TITLE
Validates total length when reading binary annotation wrapper subfields.

### DIFF
--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -255,6 +255,11 @@ class _HandlerContext(record(
             annotations = self.annotations
         if annotations is None:
             annotations = ()
+        if not (event_type is IonEventType.CONTAINER_START) and \
+                annotations and (self.limit - self.queue.position) != 0:
+            # This value is contained in an annotation wrapper, from which its limit was inherited. It must have
+            # reached, but not surpassed, that limit.
+            raise IonException('Incorrect annotation wrapper length.')
 
         if depth is None:
             depth = self.depth
@@ -279,7 +284,6 @@ class _HandlerContext(record(
 
     def derive_container_context(self, length, add_depth=1):
         new_limit = self.queue.position + length
-
         return _HandlerContext(
             self.position,
             new_limit,
@@ -504,10 +508,17 @@ def _annotation_handler(ion_type, length, ctx):
         _var_uint_field_handler(self_handler, ctx)
     )
 
+    if ann_length < 1:
+        raise IonException('Invalid annotation length subfield; annotation wrapper must have at least one annotation.')
+
     # Read/parse the annotations.
     yield ctx.read_data_transition(ann_length, self)
     ann_data = ctx.queue.read(ann_length)
     annotations = tuple(_parse_sid_iter(ann_data))
+
+    if ctx.limit - ctx.queue.position < 1:
+        # There is no space left for the 'value' subfield, which is required.
+        raise IonException('Incorrect annotation wrapper length.')
 
     # Go parse the start of the value but go back to the real parent container.
     yield ctx.immediate_transition(
@@ -521,6 +532,10 @@ def _container_start_handler(ion_type, length, ctx):
     _, self = yield
 
     container_ctx = ctx.derive_container_context(length)
+    if ctx.annotations and ctx.limit != container_ctx.limit:
+        # 'ctx' is the annotation wrapper context. `container_ctx` represents the wrapper's 'value' subfield. Their
+        # limits must match.
+        raise IonException('Incorrect annotation wrapper length.')
     delegate = _container_handler(ion_type, container_ctx)
 
     # We start the container, and transition to the new container processor.

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -93,17 +93,33 @@ _BASIC_PARAMS = (
             (e_read(b'\x0F'), IonException),
         ],
     ),
-    _P(
-        desc='OVERFLOWING TIMESTAMP PRECISION',  # Only up to microsecond precision is supported (6 digits).
-        event_pairs=[
-            (NEXT, END),
-            (e_read(b'\xE0\x01\x00\xEA'), IVM),
-            (NEXT, END),
-            (e_read(b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC7\x01'), IonException),
-        ],
-    ),
 )
 
+_BAD_VALUES = (
+    # Only up to microsecond precision is supported (6 digits).
+    (b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC7\x01', 'OVERFLOWING TIMESTAMP PRECISION'),
+    # The annotation wrapper declares 6 octets, but the wrapped value (a symbol value) ends after only 4.
+    (b'\xe6\x81\x84\x71\x04\x71\x04', 'ANNOT LENGTH TOO LONG - SCALAR'),
+    # The annotation wrapper declares 6 octets, but the wrapped value (a list) ends after only 4.
+    (b'\xe6\x81\x84\xb1\x20\x71\x04', 'ANNOT LENGTH TOO LONG - CONTAINER'),
+    # The annotation wrapper declares 4 octets, and the SIDs take up all four.
+    (b'\xe4\x83\x84\x85\x86', 'ANNOT LENGTH TOO SHORT - NO VALUE'),
+    # The annotation wrapper declares 4 octets, but the subfields (including a list) take up five.
+    (b'\xe4\x81\x84\xb2\x21\x01', 'ANNOT LENGTH TOO SHORT - CONTAINER'),
+    # The annotation wrapper declares 3 octets, but the subfields (including an int) take up four.
+    (b'\xe3\x81\x84\x21\x01', 'ANNOT LENGTH TOO SHORT - SCALAR'),
+)
+
+
+def _bad_params():
+    for pair in _BAD_VALUES:
+        yield _P(
+            desc=pair[1],
+            event_pairs=_IVM_PAIRS + [
+                (NEXT, END),
+                (e_read(pair[0]), IonException)
+            ]
+        )
 
 # This is an encoding of a single top-level value and the expected events with ``NEXT``.
 _TOP_LEVEL_VALUES = (
@@ -383,6 +399,7 @@ def _containerize_params(params, with_skip=True):
 
 @parametrize(*chain(
     _BASIC_PARAMS,
+    _bad_params(),
     _prepend_ivm(_top_level_value_params()),
     _prepend_ivm(_annotate_params(_top_level_value_params())),
     _prepend_ivm(_containerize_params(_top_level_value_params())),

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -82,8 +82,6 @@ _SKIP_LIST = (
     _equivs_file(u'structsFieldsRepeatedNames.ion'),  # TODO amznlabs/ion-python#36
     _nonequivs_file(u'structs.ion'),  # TODO amznlabs/ion-python#36
     # BINARY:
-    _bad_file(u'container_length_mismatch.10n'),  # TODO amznlabs/ion-python#37
-    _bad_file(u'emptyAnnotatedInt.10n'),  # TODO amznlabs/ion-python#37
     _good_file(u'structAnnotatedOrdered.10n'),  # TODO amznlabs/ion-python#38
     _good_file(u'structOrdered.10n'),  # TODO amznlabs/ion-python#38
 )


### PR DESCRIPTION
See #37 .

In short, the length declared by the annotation wrapper must exactly match the number of octets taken up by its subfields (including its value). This adds that validation logic.

Note: test vectors to exercise these cases have been added to ion-tests [here](https://github.com/amznlabs/ion-tests/pull/23).