### PR TITLE
Adds support for reading binary ordered structs (see #38).

### DIFF
--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -516,6 +516,24 @@ def _annotation_handler(ion_type, length, ctx):
 
 
 @coroutine
+def _ordered_struct_start_handler(handler, ctx):
+    """Handles the special case of ordered structs, specified by the type ID 0xD1.
+
+    This coroutine's only purpose is to ensure that the struct in question declares at least one field name/value pair,
+    as required by the spec.
+    """
+    _, self = yield
+    self_handler = _create_delegate_handler(self)
+    (length, _), _ = yield ctx.immediate_transition(
+        _var_uint_field_handler(self_handler, ctx)
+    )
+    if length < 2:
+        # A valid field name/value pair is at least two octets: one for the field name SID and one for the value.
+        raise IonException('Ordered structs (type ID 0xD1) must have at least one field name/value pair.')
+    yield ctx.immediate_transition(handler(length, ctx))
+
+
+@coroutine
 def _container_start_handler(ion_type, length, ctx):
     """Handles container delegation."""
     _, self = yield
@@ -755,7 +773,9 @@ def _bind_length_handlers(tids, user_handler, lns):
         for ln in lns:
             type_octet = _gen_type_octet(tid, ln)
             ion_type = _TID_VALUE_TYPE_TABLE[tid]
-            if ln < _LENGTH_FIELD_FOLLOWS:
+            if ln == 1 and ion_type is IonType.STRUCT:
+                handler = partial(_ordered_struct_start_handler, partial(user_handler, ion_type))
+            elif ln < _LENGTH_FIELD_FOLLOWS:
                 # Directly partially bind length.
                 handler = partial(user_handler, ion_type, ln)
             else:

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -235,6 +235,7 @@ _TOP_LEVEL_VALUES = (
     
     (b'\xDF', e_null_struct()),
     (b'\xD0', e_start_struct(), e_end_struct()),
+    (b'\xD1\x82\x84\x20', e_start_struct(), e_int(0, field_name=SymbolToken(None, 4)), e_end_struct())
 )
 
 

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -84,8 +84,6 @@ _SKIP_LIST = (
     # BINARY:
     _bad_file(u'container_length_mismatch.10n'),  # TODO amznlabs/ion-python#37
     _bad_file(u'emptyAnnotatedInt.10n'),  # TODO amznlabs/ion-python#37
-    _good_file(u'structAnnotatedOrdered.10n'),  # TODO amznlabs/ion-python#38
-    _good_file(u'structOrdered.10n'),  # TODO amznlabs/ion-python#38
 )
 
 _DEBUG_WHITELIST = (


### PR DESCRIPTION
See #38 .

In short, previously, the special case of type descriptor `0xd1` was not handled, resulting in length overrun for correctly formed ordered structs. This fixes that problem.

Note that the spec requires ordered structs to contain at least one field name/value pair. If that weren't required, there would be no need for `_ordered_struct_start_handler`. There is an ion-tests [pull request](https://github.com/amznlabs/ion-tests/pull/24) which adds a bad case to exercise this.